### PR TITLE
Add admin homepage image management with SSR preloading

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -13,6 +13,7 @@ import type {
   FilterApi,
   FunctionReference,
 } from "convex/server";
+import type * as homepageImages from "../homepageImages.js";
 import type * as inventory from "../inventory.js";
 import type * as projects from "../projects.js";
 import type * as users from "../users.js";
@@ -26,6 +27,7 @@ import type * as users from "../users.js";
  * ```
  */
 declare const fullApi: ApiFromModules<{
+  homepageImages: typeof homepageImages;
   inventory: typeof inventory;
   projects: typeof projects;
   users: typeof users;

--- a/convex/homepageImages.ts
+++ b/convex/homepageImages.ts
@@ -1,0 +1,407 @@
+import { v } from "convex/values";
+import { mutation, query } from "./_generated/server";
+
+// Get active homepage images for the public homepage hero slideshow
+export const getHomepageImages = query({
+  handler: async (ctx) => {
+    const images = await ctx.db
+      .query("homepageImages")
+      .withIndex("by_active_order", (q) => q.eq("active", true))
+      .collect();
+
+    return images.sort((a, b) => a.displayOrder - b.displayOrder);
+  },
+});
+
+// Get all homepage images for admin management (active + inactive)
+export const getAllHomepageImages = query({
+  handler: async (ctx) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) return [];
+
+    const user = await ctx.db
+      .query("users")
+      .withIndex("by_clerk_id", (q) => q.eq("clerkId", identity.subject))
+      .first();
+
+    if (!user || user.role !== "admin") {
+      throw new Error("Not authorized");
+    }
+
+    const images = await ctx.db.query("homepageImages").collect();
+    return images.sort((a, b) => a.displayOrder - b.displayOrder);
+  },
+});
+
+// Get available project images for admin to browse and add to homepage
+export const getAvailableProjectImages = query({
+  handler: async (ctx) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) return [];
+
+    const user = await ctx.db
+      .query("users")
+      .withIndex("by_clerk_id", (q) => q.eq("clerkId", identity.subject))
+      .first();
+
+    if (!user || user.role !== "admin") {
+      throw new Error("Not authorized");
+    }
+
+    // Get highlighted projects
+    const projects = await ctx.db
+      .query("projects")
+      .withIndex("by_highlighted", (q) => q.eq("highlighted", true))
+      .collect();
+
+    const sortedProjects = projects.sort(
+      (a, b) => (a.displayOrder || 999) - (b.displayOrder || 999)
+    );
+
+    // Get existing homepage images to detect duplicates
+    const existingHomepageImages = await ctx.db
+      .query("homepageImages")
+      .collect();
+
+    const existingProjectImageIds = new Set(
+      existingHomepageImages
+        .filter((img) => img.sourceProjectImageId)
+        .map((img) => img.sourceProjectImageId!.toString())
+    );
+
+    // Build result with images and alreadyOnHomepage flag
+    const projectsWithImages = await Promise.all(
+      sortedProjects.map(async (project) => {
+        const images = await ctx.db
+          .query("projectImages")
+          .withIndex("by_project", (q) => q.eq("projectId", project._id))
+          .collect();
+
+        const sortedImages = images.sort(
+          (a, b) => a.displayOrder - b.displayOrder
+        );
+
+        return {
+          projectId: project._id,
+          projectName: project.name,
+          images: sortedImages.map((img) => ({
+            ...img,
+            alreadyOnHomepage: existingProjectImageIds.has(img._id.toString()),
+          })),
+        };
+      })
+    );
+
+    return projectsWithImages;
+  },
+});
+
+// Add a single image to the homepage
+export const addHomepageImage = mutation({
+  args: {
+    imagePath: v.string(),
+    width: v.number(),
+    height: v.number(),
+    thumbnailPath: v.optional(v.string()),
+    thumbnailWidth: v.optional(v.number()),
+    thumbnailHeight: v.optional(v.number()),
+    title: v.optional(v.string()),
+    sourceType: v.union(v.literal("upload"), v.literal("project")),
+    sourceProjectId: v.optional(v.id("projects")),
+    sourceProjectImageId: v.optional(v.id("projectImages")),
+  },
+  handler: async (ctx, args) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) throw new Error("Not authenticated");
+
+    const user = await ctx.db
+      .query("users")
+      .withIndex("by_clerk_id", (q) => q.eq("clerkId", identity.subject))
+      .first();
+
+    if (!user || user.role !== "admin") {
+      throw new Error("Not authorized");
+    }
+
+    const existingImages = await ctx.db.query("homepageImages").collect();
+    const maxOrder = existingImages.length > 0
+      ? Math.max(...existingImages.map((img) => img.displayOrder))
+      : 0;
+
+    const imageId = await ctx.db.insert("homepageImages", {
+      imagePath: args.imagePath,
+      width: args.width,
+      height: args.height,
+      thumbnailPath: args.thumbnailPath,
+      thumbnailWidth: args.thumbnailWidth,
+      thumbnailHeight: args.thumbnailHeight,
+      title: args.title,
+      active: true,
+      displayOrder: maxOrder + 1,
+      sourceType: args.sourceType,
+      sourceProjectId: args.sourceProjectId,
+      sourceProjectImageId: args.sourceProjectImageId,
+      createdAt: Date.now(),
+    });
+
+    return imageId;
+  },
+});
+
+// Batch add multiple project images to the homepage
+export const addProjectImagesToHomepage = mutation({
+  args: {
+    projectImageIds: v.array(v.id("projectImages")),
+  },
+  handler: async (ctx, args) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) throw new Error("Not authenticated");
+
+    const user = await ctx.db
+      .query("users")
+      .withIndex("by_clerk_id", (q) => q.eq("clerkId", identity.subject))
+      .first();
+
+    if (!user || user.role !== "admin") {
+      throw new Error("Not authorized");
+    }
+
+    const existingImages = await ctx.db.query("homepageImages").collect();
+    let maxOrder = existingImages.length > 0
+      ? Math.max(...existingImages.map((img) => img.displayOrder))
+      : 0;
+
+    // Track existing source project image IDs to skip duplicates
+    const existingProjectImageIds = new Set(
+      existingImages
+        .filter((img) => img.sourceProjectImageId)
+        .map((img) => img.sourceProjectImageId!.toString())
+    );
+
+    let added = 0;
+
+    for (const projectImageId of args.projectImageIds) {
+      if (existingProjectImageIds.has(projectImageId.toString())) {
+        continue;
+      }
+
+      const projectImage = await ctx.db.get(projectImageId);
+      if (!projectImage) continue;
+
+      const project = await ctx.db.get(projectImage.projectId);
+
+      maxOrder += 1;
+
+      await ctx.db.insert("homepageImages", {
+        imagePath: projectImage.imagePath,
+        width: projectImage.width,
+        height: projectImage.height,
+        thumbnailPath: projectImage.thumbnailPath,
+        thumbnailWidth: projectImage.thumbnailWidth,
+        thumbnailHeight: projectImage.thumbnailHeight,
+        title: project ? project.name : undefined,
+        active: true,
+        displayOrder: maxOrder,
+        sourceType: "project",
+        sourceProjectId: projectImage.projectId,
+        sourceProjectImageId: projectImage._id,
+        createdAt: Date.now(),
+      });
+
+      added++;
+    }
+
+    return { added, skipped: args.projectImageIds.length - added };
+  },
+});
+
+// Remove a homepage image and re-normalize display order
+export const removeHomepageImage = mutation({
+  args: { id: v.id("homepageImages") },
+  handler: async (ctx, args) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) throw new Error("Not authenticated");
+
+    const user = await ctx.db
+      .query("users")
+      .withIndex("by_clerk_id", (q) => q.eq("clerkId", identity.subject))
+      .first();
+
+    if (!user || user.role !== "admin") {
+      throw new Error("Not authorized");
+    }
+
+    const image = await ctx.db.get(args.id);
+    if (!image) throw new Error("Homepage image not found");
+
+    await ctx.db.delete(args.id);
+
+    // Re-normalize displayOrder to prevent gaps
+    const remainingImages = await ctx.db.query("homepageImages").collect();
+    const sorted = remainingImages.sort((a, b) => a.displayOrder - b.displayOrder);
+
+    for (let i = 0; i < sorted.length; i++) {
+      if (sorted[i].displayOrder !== i + 1) {
+        await ctx.db.patch(sorted[i]._id, { displayOrder: i + 1 });
+      }
+    }
+
+    return { success: true };
+  },
+});
+
+// Update homepage image properties (title, active status)
+export const updateHomepageImage = mutation({
+  args: {
+    id: v.id("homepageImages"),
+    title: v.optional(v.string()),
+    active: v.optional(v.boolean()),
+  },
+  handler: async (ctx, args) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) throw new Error("Not authenticated");
+
+    const user = await ctx.db
+      .query("users")
+      .withIndex("by_clerk_id", (q) => q.eq("clerkId", identity.subject))
+      .first();
+
+    if (!user || user.role !== "admin") {
+      throw new Error("Not authorized");
+    }
+
+    const image = await ctx.db.get(args.id);
+    if (!image) throw new Error("Homepage image not found");
+
+    const updates: Record<string, any> = {};
+    if (args.title !== undefined) updates.title = args.title;
+    if (args.active !== undefined) updates.active = args.active;
+
+    if (Object.keys(updates).length > 0) {
+      await ctx.db.patch(args.id, updates);
+    }
+
+    return { success: true };
+  },
+});
+
+// Toggle active/inactive status on a homepage image
+export const toggleHomepageImageActive = mutation({
+  args: { id: v.id("homepageImages") },
+  handler: async (ctx, args) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) throw new Error("Not authenticated");
+
+    const user = await ctx.db
+      .query("users")
+      .withIndex("by_clerk_id", (q) => q.eq("clerkId", identity.subject))
+      .first();
+
+    if (!user || user.role !== "admin") {
+      throw new Error("Not authorized");
+    }
+
+    const image = await ctx.db.get(args.id);
+    if (!image) throw new Error("Homepage image not found");
+
+    await ctx.db.patch(args.id, {
+      active: !image.active,
+    });
+  },
+});
+
+// Reorder homepage images by receiving ordered array of IDs (for drag-and-drop)
+export const reorderHomepageImages = mutation({
+  args: {
+    imageIds: v.array(v.id("homepageImages")),
+  },
+  handler: async (ctx, args) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) throw new Error("Not authenticated");
+
+    const user = await ctx.db
+      .query("users")
+      .withIndex("by_clerk_id", (q) => q.eq("clerkId", identity.subject))
+      .first();
+
+    if (!user || user.role !== "admin") {
+      throw new Error("Not authorized");
+    }
+
+    for (let i = 0; i < args.imageIds.length; i++) {
+      await ctx.db.patch(args.imageIds[i], {
+        displayOrder: i + 1,
+      });
+    }
+
+    return { success: true };
+  },
+});
+
+// Move a homepage image one position up
+export const moveHomepageImageUp = mutation({
+  args: { id: v.id("homepageImages") },
+  handler: async (ctx, args) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) throw new Error("Not authenticated");
+
+    const user = await ctx.db
+      .query("users")
+      .withIndex("by_clerk_id", (q) => q.eq("clerkId", identity.subject))
+      .first();
+
+    if (!user || user.role !== "admin") {
+      throw new Error("Not authorized");
+    }
+
+    const image = await ctx.db.get(args.id);
+    if (!image) throw new Error("Homepage image not found");
+
+    const allImages = await ctx.db.query("homepageImages").collect();
+    const sortedImages = allImages.sort((a, b) => a.displayOrder - b.displayOrder);
+    const currentIndex = sortedImages.findIndex((img) => img._id === args.id);
+
+    if (currentIndex > 0) {
+      const prevImage = sortedImages[currentIndex - 1];
+      const currentOrder = image.displayOrder;
+      const prevOrder = prevImage.displayOrder;
+
+      await ctx.db.patch(args.id, { displayOrder: prevOrder });
+      await ctx.db.patch(prevImage._id, { displayOrder: currentOrder });
+    }
+  },
+});
+
+// Move a homepage image one position down
+export const moveHomepageImageDown = mutation({
+  args: { id: v.id("homepageImages") },
+  handler: async (ctx, args) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) throw new Error("Not authenticated");
+
+    const user = await ctx.db
+      .query("users")
+      .withIndex("by_clerk_id", (q) => q.eq("clerkId", identity.subject))
+      .first();
+
+    if (!user || user.role !== "admin") {
+      throw new Error("Not authorized");
+    }
+
+    const image = await ctx.db.get(args.id);
+    if (!image) throw new Error("Homepage image not found");
+
+    const allImages = await ctx.db.query("homepageImages").collect();
+    const sortedImages = allImages.sort((a, b) => a.displayOrder - b.displayOrder);
+    const currentIndex = sortedImages.findIndex((img) => img._id === args.id);
+
+    if (currentIndex < sortedImages.length - 1) {
+      const nextImage = sortedImages[currentIndex + 1];
+      const currentOrder = image.displayOrder;
+      const nextOrder = nextImage.displayOrder;
+
+      await ctx.db.patch(args.id, { displayOrder: nextOrder });
+      await ctx.db.patch(nextImage._id, { displayOrder: currentOrder });
+    }
+  },
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -126,4 +126,23 @@ export default defineSchema({
   })
     .index("by_created", ["createdAt"])
     .index("by_responded", ["responded"]),
+
+  homepageImages: defineTable({
+    imagePath: v.string(),
+    width: v.number(),
+    height: v.number(),
+    thumbnailPath: v.optional(v.string()),
+    thumbnailWidth: v.optional(v.number()),
+    thumbnailHeight: v.optional(v.number()),
+    title: v.optional(v.string()),
+    active: v.boolean(),
+    displayOrder: v.number(),
+    sourceType: v.union(v.literal("upload"), v.literal("project")),
+    sourceProjectId: v.optional(v.id("projects")),
+    sourceProjectImageId: v.optional(v.id("projectImages")),
+    createdAt: v.number(),
+  })
+    .index("by_active_order", ["active", "displayOrder"])
+    .index("by_order", ["displayOrder"])
+    .index("by_source_project_image", ["sourceProjectImageId"]),
 });

--- a/src/app/_main_components/home.tsx
+++ b/src/app/_main_components/home.tsx
@@ -1,10 +1,18 @@
 'use client';
 
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, useMemo } from 'react';
 import Image from 'next/image';
 import { motion, AnimatePresence } from 'framer-motion';
+import { useQuery } from 'convex/react';
+import { api } from '@/convex/_generated/api';
 
-const images = [
+type HomepageImage = {
+    src: string;
+    width: number;
+    height: number;
+};
+
+const FALLBACK_IMAGES: HomepageImage[] = [
     { src: '/portfolio/stock/staging-stock-3.jpg', width: 2560, height: 1695 },
     { src: '/portfolio/stock/staging-stock-7.jpg', width: 564, height: 705 },
     { src: '/portfolio/stock/staging-stock-1.png', width: 2048, height: 1366 },
@@ -14,11 +22,55 @@ const images = [
 
 const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
-export default function Home() {
+interface InitialHomepageImage {
+    imagePath: string;
+    width: number;
+    height: number;
+}
+
+export default function Home({
+    initialHomepageImages,
+}: {
+    initialHomepageImages?: InitialHomepageImage[] | null;
+}) {
+    // Client-side query for real-time updates after hydration
+    const homepageImagesData = useQuery(api.homepageImages.getHomepageImages);
+
     const [isLogoVisible, setLogoVisible] = useState(true);
     const [isStagingImageVisible, setStagingImageVisible] = useState(true);
     const currentImageIndexRef = useRef(0);
 
+    // Priority: live Convex data > SSR-preloaded data > hardcoded fallback
+    const images: HomepageImage[] = useMemo(() => {
+        // 1. Use live Convex data once available (real-time, always up-to-date)
+        if (homepageImagesData && homepageImagesData.length > 0) {
+            return homepageImagesData.map((img: { imagePath: string; width: number; height: number }) => ({
+                src: img.imagePath,
+                width: img.width,
+                height: img.height,
+            }));
+        }
+        // 2. Use SSR-preloaded data (available immediately, no loading delay)
+        if (initialHomepageImages && initialHomepageImages.length > 0) {
+            return initialHomepageImages.map((img) => ({
+                src: img.imagePath,
+                width: img.width,
+                height: img.height,
+            }));
+        }
+        // 3. Ultimate fallback to hardcoded local images
+        return FALLBACK_IMAGES;
+    }, [homepageImagesData, initialHomepageImages]);
+
+    // Preload all images for smooth transitions
+    useEffect(() => {
+        images.forEach((image) => {
+            const img = new window.Image();
+            img.src = image.src;
+        });
+    }, [images]);
+
+    // Image rotation interval
     useEffect(() => {
         const interval = setInterval(async () => {
             setStagingImageVisible(false);
@@ -28,7 +80,16 @@ export default function Home() {
         }, 5500);
 
         return () => clearInterval(interval);
-    }, []);
+    }, [images.length]);
+
+    // Reset image index if images array shrinks below current index
+    useEffect(() => {
+        if (currentImageIndexRef.current >= images.length) {
+            currentImageIndexRef.current = 0;
+            setStagingImageVisible(false);
+            setTimeout(() => setStagingImageVisible(true), 100);
+        }
+    }, [images.length]);
 
     const circularFadeVariants = {
         hidden: {

--- a/src/app/admin/manage/homepage/HomepageManageClient.tsx
+++ b/src/app/admin/manage/homepage/HomepageManageClient.tsx
@@ -1,0 +1,751 @@
+'use client';
+
+import { useState, useEffect, useRef, useMemo } from 'react';
+import { useQuery, useMutation } from 'convex/react';
+import { api } from '@/convex/_generated/api';
+import { Id, Doc } from '@/convex/_generated/dataModel';
+import Image from 'next/image';
+import { motion, AnimatePresence } from 'framer-motion';
+import {
+    Eye,
+    EyeOff,
+    Pencil,
+    Trash2,
+    Upload,
+    Images,
+    Check,
+    ImageIcon,
+    Loader2,
+} from 'lucide-react';
+import { Tooltip } from 'react-tooltip';
+import ProjectResizeUploader from '@/components/ProjectResizeUploader';
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+type HomepageImageDoc = Doc<'homepageImages'>;
+
+interface ProjectWithImages {
+    projectId: Id<'projects'>;
+    projectName: string;
+    images: Array<
+        Doc<'projectImages'> & {
+            alreadyOnHomepage: boolean;
+        }
+    >;
+}
+
+// ─── Live Preview Strip ─────────────────────────────────────────────────────
+
+function LivePreviewStrip({ images }: { images: HomepageImageDoc[] }) {
+    const [currentIndex, setCurrentIndex] = useState(0);
+    const [isVisible, setIsVisible] = useState(true);
+    const [isPaused, setIsPaused] = useState(false);
+    const indexRef = useRef(0);
+
+    useEffect(() => {
+        if (images.length === 0 || isPaused) return;
+
+        const interval = setInterval(async () => {
+            setIsVisible(false);
+            await new Promise((r) => setTimeout(r, 1200));
+            indexRef.current = (indexRef.current + 1) % images.length;
+            setCurrentIndex(indexRef.current);
+            setIsVisible(true);
+        }, 4500);
+
+        return () => clearInterval(interval);
+    }, [images.length, isPaused]);
+
+    useEffect(() => {
+        if (indexRef.current >= images.length) {
+            indexRef.current = 0;
+            setCurrentIndex(0);
+        }
+    }, [images.length]);
+
+    if (images.length === 0) {
+        return (
+            <div className="relative mx-4 mt-4 flex h-48 items-center justify-center overflow-hidden rounded-xl border border-stone-700 bg-stone-800/50">
+                <p className="text-sm text-stone-500">No active images to preview</p>
+            </div>
+        );
+    }
+
+    return (
+        <div
+            className="relative mx-4 mt-4 h-48 overflow-hidden rounded-xl border border-stone-700"
+            onMouseEnter={() => setIsPaused(true)}
+            onMouseLeave={() => setIsPaused(false)}
+        >
+            <AnimatePresence>
+                {isVisible && images[currentIndex] && (
+                    <motion.div
+                        key={currentIndex}
+                        initial={{ opacity: 0, scale: 1 }}
+                        animate={{ opacity: 1, scale: 1.15 }}
+                        exit={{ opacity: 0 }}
+                        transition={{ duration: 2.5 }}
+                        className="absolute inset-0"
+                    >
+                        <Image
+                            src={images[currentIndex].imagePath}
+                            width={images[currentIndex].width}
+                            height={images[currentIndex].height}
+                            className="h-full w-full object-cover"
+                            alt="Homepage preview"
+                            sizes="100vw"
+                        />
+                    </motion.div>
+                )}
+            </AnimatePresence>
+
+            <div className="absolute inset-0 bg-gradient-to-r from-stone-900/50 via-transparent to-stone-900/50" />
+
+            <div className="absolute bottom-3 left-4">
+                <span className="rounded-full bg-stone-900/70 px-3 py-1 text-xs font-medium text-primary">
+                    Live Preview
+                </span>
+            </div>
+
+            <div className="absolute bottom-3 right-4 flex gap-1.5">
+                {images.map((_: HomepageImageDoc, i: number) => (
+                    <div
+                        key={i}
+                        className={`h-2 w-2 rounded-full transition-colors ${i === currentIndex ? 'bg-primary' : 'bg-stone-500'}`}
+                    />
+                ))}
+            </div>
+        </div>
+    );
+}
+
+// ─── Homepage Image Card ────────────────────────────────────────────────────
+
+function HomepageImageCard({
+    image,
+    position,
+    onToggleActive,
+    onRemove,
+    onEditCaption,
+    onDragStart,
+    onDragOver,
+    onDrop,
+    isDragTarget,
+}: {
+    image: HomepageImageDoc;
+    position: number;
+    onToggleActive: () => void;
+    onRemove: () => void;
+    onEditCaption: () => void;
+    onDragStart: (e: React.DragEvent<HTMLDivElement>) => void;
+    onDragOver: (e: React.DragEvent<HTMLDivElement>) => void;
+    onDrop: (e: React.DragEvent<HTMLDivElement>) => void;
+    isDragTarget: boolean;
+}) {
+    return (
+        <div
+            draggable
+            onDragStart={onDragStart}
+            onDragOver={onDragOver}
+            onDrop={onDrop}
+            className={`group relative cursor-grab overflow-hidden rounded-xl bg-stone-800 shadow-lg transition-all duration-300 hover:shadow-xl hover:shadow-primary/5 active:cursor-grabbing ${
+                !image.active ? 'opacity-50 grayscale' : ''
+            } ${isDragTarget ? 'ring-2 ring-primary ring-offset-2 ring-offset-stone-900' : ''}`}
+        >
+            {/* Image */}
+            <div className="relative aspect-[16/10] overflow-hidden">
+                <Image
+                    src={image.thumbnailPath || image.imagePath}
+                    width={image.thumbnailWidth || image.width}
+                    height={image.thumbnailHeight || image.height}
+                    className="h-full w-full object-cover transition-transform duration-500 group-hover:scale-105"
+                    alt={image.title || 'Homepage image'}
+                    sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 25vw"
+                />
+
+                {/* Position badge */}
+                <div className="absolute left-3 top-3 flex h-8 w-8 items-center justify-center rounded-full bg-primary font-bold text-stone-900 text-sm shadow-md">
+                    {position}
+                </div>
+
+                {/* Active/Inactive badge */}
+                <div
+                    className={`absolute right-3 top-3 rounded-full px-2.5 py-0.5 text-xs font-medium ${
+                        image.active ? 'bg-secondary/90 text-white' : 'bg-stone-600/90 text-stone-300'
+                    }`}
+                >
+                    {image.active ? 'Active' : 'Inactive'}
+                </div>
+
+                {/* Hover overlay with actions */}
+                <div className="absolute inset-0 flex items-center justify-center gap-3 bg-stone-900/60 opacity-0 transition-opacity duration-300 group-hover:opacity-100">
+                    <button
+                        onClick={(e) => {
+                            e.stopPropagation();
+                            onToggleActive();
+                        }}
+                        className="flex h-10 w-10 items-center justify-center rounded-full bg-stone-800/90 text-stone-300 transition-colors hover:bg-secondary hover:text-white"
+                        data-tooltip-id="homepage-tooltip"
+                        data-tooltip-content={image.active ? 'Set Inactive' : 'Set Active'}
+                    >
+                        {image.active ? <EyeOff size={18} /> : <Eye size={18} />}
+                    </button>
+
+                    <button
+                        onClick={(e) => {
+                            e.stopPropagation();
+                            onEditCaption();
+                        }}
+                        className="flex h-10 w-10 items-center justify-center rounded-full bg-stone-800/90 text-stone-300 transition-colors hover:bg-primary hover:text-stone-900"
+                        data-tooltip-id="homepage-tooltip"
+                        data-tooltip-content="Edit caption"
+                    >
+                        <Pencil size={18} />
+                    </button>
+
+                    <button
+                        onClick={(e) => {
+                            e.stopPropagation();
+                            onRemove();
+                        }}
+                        className="flex h-10 w-10 items-center justify-center rounded-full bg-stone-800/90 text-stone-300 transition-colors hover:bg-red-600 hover:text-white"
+                        data-tooltip-id="homepage-tooltip"
+                        data-tooltip-content="Remove from homepage"
+                    >
+                        <Trash2 size={18} />
+                    </button>
+                </div>
+            </div>
+
+            {/* Caption */}
+            <div className="px-3 py-2">
+                <p className="truncate text-sm text-stone-400">{image.title || 'No caption'}</p>
+                {image.sourceType === 'project' && (
+                    <p className="mt-0.5 truncate text-xs text-stone-500">From project</p>
+                )}
+            </div>
+        </div>
+    );
+}
+
+// ─── Main Component ─────────────────────────────────────────────────────────
+
+export default function HomepageManageClient() {
+    // Convex queries
+    const homepageImages = useQuery(api.homepageImages.getAllHomepageImages);
+    const availableProjects = useQuery(api.homepageImages.getAvailableProjectImages);
+
+    // Convex mutations
+    const addHomepageImage = useMutation(api.homepageImages.addHomepageImage);
+    const addProjectImagesToHomepage = useMutation(api.homepageImages.addProjectImagesToHomepage);
+    const removeHomepageImage = useMutation(api.homepageImages.removeHomepageImage);
+    const toggleActive = useMutation(api.homepageImages.toggleHomepageImageActive);
+    const updateHomepageImage = useMutation(api.homepageImages.updateHomepageImage);
+    const reorderHomepageImages = useMutation(api.homepageImages.reorderHomepageImages);
+
+    // UI state
+    const [addTab, setAddTab] = useState<'projects' | 'upload'>('projects');
+    const [selectedProject, setSelectedProject] = useState(0);
+    const [selectedProjectImages, setSelectedProjectImages] = useState<Set<string>>(new Set());
+    const [editingCaptionId, setEditingCaptionId] = useState<string | null>(null);
+    const [captionInput, setCaptionInput] = useState('');
+    const [draggedIndex, setDraggedIndex] = useState<number | null>(null);
+    const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
+    const [isAdding, setIsAdding] = useState(false);
+    const [uploadCaption, setUploadCaption] = useState('');
+    const [pendingUpload, setPendingUpload] = useState<{
+        originalImageUrl: string;
+        smallImageUrl: string;
+        originalWidth: number;
+        originalHeight: number;
+        smallWidth: number;
+        smallHeight: number;
+    } | null>(null);
+
+    // Active images for preview
+    const activeImages = useMemo(() => {
+        if (!homepageImages) return [];
+        return homepageImages.filter((img: HomepageImageDoc) => img.active);
+    }, [homepageImages]);
+
+    // ─── Caption Editing ────────────────────────────────────────────────
+
+    const startEditCaption = (image: HomepageImageDoc) => {
+        setEditingCaptionId(image._id);
+        setCaptionInput(image.title || '');
+    };
+
+    const saveCaption = async () => {
+        if (editingCaptionId) {
+            await updateHomepageImage({
+                id: editingCaptionId as Id<'homepageImages'>,
+                title: captionInput,
+            });
+            setEditingCaptionId(null);
+            setCaptionInput('');
+        }
+    };
+
+    // ─── Drag and Drop ─────────────────────────────────────────────────
+
+    const handleDragStart = (index: number) => (e: React.DragEvent<HTMLDivElement>) => {
+        setDraggedIndex(index);
+        e.dataTransfer.effectAllowed = 'move';
+    };
+
+    const handleDragOver = (index: number) => (e: React.DragEvent<HTMLDivElement>) => {
+        e.preventDefault();
+        e.dataTransfer.dropEffect = 'move';
+        setDragOverIndex(index);
+    };
+
+    const handleDrop = (dropIndex: number) => async (e: React.DragEvent<HTMLDivElement>) => {
+        e.preventDefault();
+        if (draggedIndex === null || draggedIndex === dropIndex || !homepageImages) return;
+
+        const newOrder = [...homepageImages];
+        const [draggedItem] = newOrder.splice(draggedIndex, 1);
+        newOrder.splice(dropIndex, 0, draggedItem);
+
+        await reorderHomepageImages({
+            imageIds: newOrder.map((img: HomepageImageDoc) => img._id),
+        });
+
+        setDraggedIndex(null);
+        setDragOverIndex(null);
+    };
+
+    const handleDragEnd = () => {
+        setDraggedIndex(null);
+        setDragOverIndex(null);
+    };
+
+    // ─── Remove Image ──────────────────────────────────────────────────
+
+    const handleRemove = async (id: Id<'homepageImages'>) => {
+        await removeHomepageImage({ id });
+    };
+
+    // ─── Add From Projects ─────────────────────────────────────────────
+
+    const toggleProjectImageSelection = (imageId: string) => {
+        setSelectedProjectImages((prev) => {
+            const next = new Set(prev);
+            if (next.has(imageId)) {
+                next.delete(imageId);
+            } else {
+                next.add(imageId);
+            }
+            return next;
+        });
+    };
+
+    const handleSelectAllFromProject = () => {
+        if (!availableProjects || availableProjects.length === 0) return;
+        const project = availableProjects[selectedProject] as ProjectWithImages | undefined;
+        if (!project) return;
+
+        const selectableIds = project.images
+            .filter((img) => !img.alreadyOnHomepage)
+            .map((img) => img._id.toString());
+
+        const allSelected = selectableIds.every((id: string) => selectedProjectImages.has(id));
+
+        if (allSelected) {
+            setSelectedProjectImages((prev) => {
+                const next = new Set(prev);
+                selectableIds.forEach((id: string) => next.delete(id));
+                return next;
+            });
+        } else {
+            setSelectedProjectImages((prev) => {
+                const next = new Set(prev);
+                selectableIds.forEach((id: string) => next.add(id));
+                return next;
+            });
+        }
+    };
+
+    const handleAddSelectedToHomepage = async () => {
+        if (selectedProjectImages.size === 0) return;
+        setIsAdding(true);
+        try {
+            await addProjectImagesToHomepage({
+                projectImageIds: Array.from(selectedProjectImages) as Id<'projectImages'>[],
+            });
+            setSelectedProjectImages(new Set());
+        } finally {
+            setIsAdding(false);
+        }
+    };
+
+    // ─── Upload ────────────────────────────────────────────────────────
+
+    const handleUploadComplete = (
+        images: Array<{
+            fileName: string;
+            originalImageUrl: string;
+            smallImageUrl: string;
+            originalWidth: number;
+            originalHeight: number;
+            smallWidth: number;
+            smallHeight: number;
+        }>,
+    ) => {
+        if (images.length > 0) {
+            setPendingUpload(images[0]);
+        }
+    };
+
+    const handleAddUploadedImage = async () => {
+        if (!pendingUpload) return;
+        setIsAdding(true);
+        try {
+            await addHomepageImage({
+                imagePath: pendingUpload.originalImageUrl,
+                width: pendingUpload.originalWidth,
+                height: pendingUpload.originalHeight,
+                thumbnailPath: pendingUpload.smallImageUrl,
+                thumbnailWidth: pendingUpload.smallWidth,
+                thumbnailHeight: pendingUpload.smallHeight,
+                title: uploadCaption || undefined,
+                sourceType: 'upload',
+            });
+            setPendingUpload(null);
+            setUploadCaption('');
+        } finally {
+            setIsAdding(false);
+        }
+    };
+
+    // ─── Loading State ─────────────────────────────────────────────────
+
+    if (homepageImages === undefined) {
+        return (
+            <div className="flex h-full items-center justify-center bg-stone-900">
+                <Loader2 className="h-8 w-8 animate-spin text-primary" />
+            </div>
+        );
+    }
+
+    const currentProject = availableProjects?.[selectedProject] as ProjectWithImages | undefined;
+
+    return (
+        <div className="flex h-full w-full flex-col bg-stone-900" onDragEnd={handleDragEnd}>
+            {/* Live Preview Strip */}
+            <LivePreviewStrip images={activeImages} />
+
+            {/* Scrollable content */}
+            <div className="flex-grow overflow-y-auto px-4 pb-8">
+                {/* ─── Current Homepage Images ──────────────────────────────── */}
+                <div className="mt-6">
+                    <div className="mb-4 flex items-center justify-between">
+                        <h2 className="text-xl font-semibold text-stone-200">
+                            Homepage Slideshow
+                            <span className="ml-2 text-sm font-normal text-stone-500">
+                                ({activeImages.length} active of {homepageImages.length} total)
+                            </span>
+                        </h2>
+                        <p className="text-xs text-stone-500">Drag to reorder</p>
+                    </div>
+
+                    {homepageImages.length === 0 ? (
+                        /* Empty State */
+                        <div className="flex flex-col items-center justify-center rounded-xl border-2 border-dashed border-stone-700 py-16 text-center">
+                            <ImageIcon size={64} className="mb-4 text-stone-600" />
+                            <h3 className="text-xl font-semibold text-stone-300">No Homepage Images Yet</h3>
+                            <p className="mt-2 max-w-md text-stone-500">
+                                Add images from your projects or upload new ones to create a stunning hero slideshow.
+                            </p>
+                            <button
+                                onClick={() => setAddTab('projects')}
+                                className="mt-6 rounded-lg bg-primary px-6 py-2.5 font-medium text-stone-900 transition-colors hover:bg-primary_dark"
+                            >
+                                Browse Project Images
+                            </button>
+                        </div>
+                    ) : (
+                        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+                            {homepageImages.map((image: HomepageImageDoc, index: number) => (
+                                <HomepageImageCard
+                                    key={image._id}
+                                    image={image}
+                                    position={index + 1}
+                                    onToggleActive={() => toggleActive({ id: image._id })}
+                                    onRemove={() => handleRemove(image._id)}
+                                    onEditCaption={() => startEditCaption(image)}
+                                    onDragStart={handleDragStart(index)}
+                                    onDragOver={handleDragOver(index)}
+                                    onDrop={handleDrop(index)}
+                                    isDragTarget={dragOverIndex === index && draggedIndex !== index}
+                                />
+                            ))}
+                        </div>
+                    )}
+
+                    {/* Warning when all images are inactive */}
+                    {homepageImages.length > 0 && activeImages.length === 0 && (
+                        <div className="mt-4 rounded-lg border border-amber-600/50 bg-amber-900/20 p-3 text-sm text-amber-300">
+                            All images are inactive. The homepage will display default fallback images.
+                        </div>
+                    )}
+                </div>
+
+                {/* ─── Caption Edit Modal ───────────────────────────────────── */}
+                {editingCaptionId && (
+                    <div
+                        className="fixed inset-0 z-50 flex items-center justify-center bg-stone-900/80"
+                        onClick={() => setEditingCaptionId(null)}
+                    >
+                        <div
+                            onClick={(e) => e.stopPropagation()}
+                            className="w-full max-w-md rounded-xl bg-stone-800 p-6 shadow-2xl"
+                        >
+                            <h3 className="mb-4 text-lg font-semibold text-stone-200">Edit Caption</h3>
+                            <input
+                                type="text"
+                                value={captionInput}
+                                onChange={(e) => setCaptionInput(e.target.value)}
+                                onKeyDown={(e) => e.key === 'Enter' && saveCaption()}
+                                className="w-full rounded-lg border border-stone-600 bg-stone-700 px-4 py-2.5 text-stone-100 focus:border-primary focus:outline-none"
+                                placeholder="Enter a caption..."
+                                autoFocus
+                            />
+                            <div className="mt-4 flex justify-end gap-3">
+                                <button
+                                    onClick={() => setEditingCaptionId(null)}
+                                    className="rounded-lg px-4 py-2 text-sm text-stone-400 transition-colors hover:text-stone-200"
+                                >
+                                    Cancel
+                                </button>
+                                <button
+                                    onClick={saveCaption}
+                                    className="rounded-lg bg-primary px-4 py-2 text-sm font-medium text-stone-900 transition-colors hover:bg-primary_dark"
+                                >
+                                    Save
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                )}
+
+                {/* ─── Divider ──────────────────────────────────────────────── */}
+                <div className="my-8 border-t border-stone-700" />
+
+                {/* ─── Add Images Section ───────────────────────────────────── */}
+                <div>
+                    <h2 className="mb-4 text-xl font-semibold text-stone-200">Add Images</h2>
+
+                    {/* Tab Navigation */}
+                    <div className="mb-6 flex gap-1 rounded-lg bg-stone-800 p-1">
+                        <button
+                            onClick={() => setAddTab('projects')}
+                            className={`flex flex-1 items-center justify-center gap-2 rounded-md px-3 py-2.5 text-sm font-medium transition-colors ${
+                                addTab === 'projects' ? 'bg-primary text-stone-900' : 'text-stone-400 hover:text-stone-200'
+                            }`}
+                        >
+                            <Images size={16} />
+                            From Projects
+                        </button>
+                        <button
+                            onClick={() => setAddTab('upload')}
+                            className={`flex flex-1 items-center justify-center gap-2 rounded-md px-3 py-2.5 text-sm font-medium transition-colors ${
+                                addTab === 'upload' ? 'bg-primary text-stone-900' : 'text-stone-400 hover:text-stone-200'
+                            }`}
+                        >
+                            <Upload size={16} />
+                            Upload New
+                        </button>
+                    </div>
+
+                    {/* ─── Tab: From Projects ──────────────────────────────── */}
+                    {addTab === 'projects' && (
+                        <div>
+                            {!availableProjects ? (
+                                <div className="flex items-center justify-center py-12">
+                                    <Loader2 className="h-6 w-6 animate-spin text-stone-500" />
+                                </div>
+                            ) : availableProjects.length === 0 ? (
+                                <div className="py-12 text-center text-stone-500">
+                                    No highlighted projects available. Mark projects as highlighted in the Projects admin page.
+                                </div>
+                            ) : (
+                                <>
+                                    {/* Project selector pills */}
+                                    <div className="mb-4 flex flex-wrap gap-2">
+                                        {availableProjects.map((project: ProjectWithImages, index: number) => (
+                                            <button
+                                                key={project.projectId}
+                                                onClick={() => {
+                                                    setSelectedProject(index);
+                                                    setSelectedProjectImages(new Set());
+                                                }}
+                                                className={`rounded-full border-2 px-4 py-1.5 text-sm font-medium transition-all ${
+                                                    index === selectedProject
+                                                        ? 'border-secondary bg-secondary text-stone-200'
+                                                        : 'border-stone-600 bg-transparent text-stone-400 hover:border-primary hover:text-primary'
+                                                }`}
+                                            >
+                                                {project.projectName}
+                                                <span className="ml-1.5 text-xs opacity-70">({project.images.length})</span>
+                                            </button>
+                                        ))}
+                                    </div>
+
+                                    {/* Batch action bar */}
+                                    {currentProject && currentProject.images.length > 0 && (
+                                        <div className="mb-4 flex items-center justify-between">
+                                            <span className="text-sm text-stone-400">
+                                                {selectedProjectImages.size > 0
+                                                    ? `${selectedProjectImages.size} selected`
+                                                    : 'Click images to select'}
+                                            </span>
+                                            <div className="flex gap-2">
+                                                <button
+                                                    onClick={handleSelectAllFromProject}
+                                                    className="rounded bg-stone-700 px-3 py-1.5 text-xs text-stone-300 transition-colors hover:bg-stone-600"
+                                                >
+                                                    {currentProject.images.filter((img) => !img.alreadyOnHomepage).length ===
+                                                        selectedProjectImages.size &&
+                                                    selectedProjectImages.size > 0
+                                                        ? 'Deselect All'
+                                                        : 'Select All'}
+                                                </button>
+                                                <button
+                                                    onClick={handleAddSelectedToHomepage}
+                                                    disabled={selectedProjectImages.size === 0 || isAdding}
+                                                    className="rounded bg-primary px-4 py-1.5 text-xs font-medium text-stone-900 transition-colors hover:bg-primary_dark disabled:cursor-not-allowed disabled:opacity-50"
+                                                >
+                                                    {isAdding ? (
+                                                        <Loader2 size={14} className="inline animate-spin" />
+                                                    ) : (
+                                                        `Add ${selectedProjectImages.size} to Homepage`
+                                                    )}
+                                                </button>
+                                            </div>
+                                        </div>
+                                    )}
+
+                                    {/* Project image grid */}
+                                    {currentProject && (
+                                        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
+                                            {currentProject.images.map((image) => {
+                                                const isSelected = selectedProjectImages.has(image._id.toString());
+                                                const alreadyAdded = image.alreadyOnHomepage;
+
+                                                return (
+                                                    <div
+                                                        key={image._id}
+                                                        onClick={() =>
+                                                            !alreadyAdded && toggleProjectImageSelection(image._id.toString())
+                                                        }
+                                                        className={`relative cursor-pointer overflow-hidden rounded-lg transition-all duration-200 ${
+                                                            alreadyAdded
+                                                                ? 'cursor-not-allowed opacity-40'
+                                                                : isSelected
+                                                                  ? 'scale-[0.97] ring-2 ring-primary'
+                                                                  : 'hover:ring-2 hover:ring-stone-500'
+                                                        }`}
+                                                    >
+                                                        <Image
+                                                            src={image.thumbnailPath || image.imagePath}
+                                                            width={image.thumbnailWidth || image.width}
+                                                            height={image.thumbnailHeight || image.height}
+                                                            className="aspect-square w-full object-cover"
+                                                            alt="Project image"
+                                                            sizes="(max-width: 640px) 50vw, (max-width: 1024px) 25vw, 20vw"
+                                                        />
+
+                                                        {/* Selection check */}
+                                                        {isSelected && (
+                                                            <div className="absolute right-2 top-2 flex h-6 w-6 items-center justify-center rounded-full bg-primary text-stone-900">
+                                                                <Check size={14} />
+                                                            </div>
+                                                        )}
+
+                                                        {/* Already added overlay */}
+                                                        {alreadyAdded && (
+                                                            <div className="absolute inset-0 flex items-center justify-center bg-stone-900/50">
+                                                                <span className="rounded bg-stone-700 px-2 py-1 text-xs text-stone-300">
+                                                                    Already Added
+                                                                </span>
+                                                            </div>
+                                                        )}
+                                                    </div>
+                                                );
+                                            })}
+                                        </div>
+                                    )}
+
+                                    {currentProject && currentProject.images.length === 0 && (
+                                        <div className="py-12 text-center text-stone-500">
+                                            This project has no images yet.
+                                        </div>
+                                    )}
+                                </>
+                            )}
+                        </div>
+                    )}
+
+                    {/* ─── Tab: Upload New ─────────────────────────────────── */}
+                    {addTab === 'upload' && (
+                        <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+                            <div className="space-y-4">
+                                <ProjectResizeUploader
+                                    onUploadComplete={handleUploadComplete}
+                                    onResetInputs={() => setPendingUpload(null)}
+                                />
+
+                                <div>
+                                    <label className="mb-1 block text-sm font-medium text-stone-300">
+                                        Caption (optional)
+                                    </label>
+                                    <input
+                                        type="text"
+                                        value={uploadCaption}
+                                        onChange={(e) => setUploadCaption(e.target.value)}
+                                        className="w-full rounded-lg border border-stone-600 bg-stone-700 px-3 py-2 text-stone-100 focus:border-primary focus:outline-none"
+                                        placeholder="Enter a caption for this image..."
+                                    />
+                                </div>
+
+                                <button
+                                    onClick={handleAddUploadedImage}
+                                    disabled={!pendingUpload || isAdding}
+                                    className="w-full rounded-lg bg-secondary py-2.5 font-medium text-white transition-colors hover:bg-secondary_light disabled:cursor-not-allowed disabled:opacity-50"
+                                >
+                                    {isAdding ? (
+                                        <Loader2 size={18} className="mx-auto animate-spin" />
+                                    ) : (
+                                        'Add to Homepage'
+                                    )}
+                                </button>
+                            </div>
+
+                            {/* Preview */}
+                            <div className="flex aspect-[16/10] items-center justify-center overflow-hidden rounded-xl bg-stone-800">
+                                {pendingUpload ? (
+                                    <Image
+                                        src={pendingUpload.originalImageUrl}
+                                        width={pendingUpload.originalWidth}
+                                        height={pendingUpload.originalHeight}
+                                        className="h-full w-full object-cover"
+                                        alt="Upload preview"
+                                        sizes="50vw"
+                                    />
+                                ) : (
+                                    <div className="text-center text-stone-500">
+                                        <Upload size={48} className="mx-auto mb-3 opacity-40" />
+                                        <p>Upload an image to see preview</p>
+                                    </div>
+                                )}
+                            </div>
+                        </div>
+                    )}
+                </div>
+            </div>
+
+            <Tooltip id="homepage-tooltip" className="z-50" />
+        </div>
+    );
+}

--- a/src/app/admin/manage/homepage/page.tsx
+++ b/src/app/admin/manage/homepage/page.tsx
@@ -1,0 +1,44 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+    title: 'Capital City Staging - Manage Homepage',
+    description:
+        "Capital City Staging allows you to focus on your next moves, we'll handle your history. With a home staged by Mia, you can trust that every room tells your story.",
+    keywords:
+        'Capital City Staging, Sacramento Staging, Mia Capital City Staging, Mia Realtor, Mia Staging, Staging, Homestaging, Real Estate, Staging Services, Staging Software, Homestaging, Real Estate, Real Estate Staging, Real Estate Staging Services, Real Estate Staging Software, Mia, Mia Dofflemyer, Home Staging, Sacramento, Sacramento Home Staging, Sacramento Real Estate, Sacramento Real Estate Staging, Sacramento Real Estate Staging Services, Sacramento Staging Services, Capital City, Capital, City, City Stage, City Staging',
+    applicationName: 'Capital City Staging',
+    icons: {
+        icon: '/logo/CCS_logo_152x152.png',
+        shortcut: '/logo/CCS_logo_152x152.png',
+        apple: '/logo/apple-touch-icon-152x152.png',
+    },
+    openGraph: {
+        title: 'Capital City Staging - Manage Homepage',
+        description:
+            "Capital City Staging allows you to focus on your next moves, we'll handle your history. With a home staged by Mia, you can trust that every room tells your story.",
+        siteName: 'Capital City Staging',
+        url: 'https://www.capitalcitystaging.com',
+        images: [
+            {
+                url: '/favicon/CCS_og_image.png',
+                width: 1200,
+                height: 630,
+                alt: 'Capital City Staging',
+            },
+        ],
+        locale: 'en_US',
+        type: 'website',
+    },
+    metadataBase: new URL('https://www.capitalcitystaging.com'),
+};
+
+import PageLayout from '@/components/layout/PageLayout';
+import HomepageManageClient from './HomepageManageClient';
+
+export default function ManageHomepagePage() {
+    return (
+        <PageLayout page="/admin/manage/homepage">
+            <HomepageManageClient />
+        </PageLayout>
+    );
+}

--- a/src/app/main_view.tsx
+++ b/src/app/main_view.tsx
@@ -1,15 +1,12 @@
 'use client';
 
 import React, { useRef, useLayoutEffect, useEffect, useState } from 'react';
-import Head from 'next/head';
-import Link from 'next/link';
 import { useStore } from '@/stores/store';
 
 import Home from '@/app/_main_components/home';
 import About from '@/app/_main_components/about';
 import Portfolio from '@/app/_main_components/portfolio';
 import Services from '@/app/_main_components/services';
-// import Testimonials from '@/app/_main_components/testimonials';
 
 import dynamic from 'next/dynamic';
 const PostHogPageView = dynamic(() => import('@/app/PostHogPageView'), {
@@ -24,11 +21,20 @@ const components = [
     { id: 'portfolio', component: Portfolio },
     { id: 'where', component: Where },
     { id: 'services', component: Services },
-    //{ id: 'testimonials', component: Testimonials },
     { id: 'about', component: About },
 ];
 
-export default function MainView() {
+interface InitialHomepageImage {
+    imagePath: string;
+    width: number;
+    height: number;
+}
+
+export default function MainView({
+    initialHomepageImages,
+}: {
+    initialHomepageImages?: InitialHomepageImage[] | null;
+}) {
     const [layoutLoaded, setLayoutLoaded] = useState(false);
     const componentRefs = useStore((state) => state.componentRefs);
     const setComponentRefs = useStore((state) => state.setComponentRefs);
@@ -67,12 +73,13 @@ export default function MainView() {
     return (
         <div className="flex h-full flex-col overflow-y-auto">
             <PostHogPageView />
-            <Head>
-                <link rel="preload" as="image" href="/portfolio/stock/staging-stock-3.jpg" imageSizes="100vw" />
-            </Head>
             {components.map(({ id, component: Component }, index) => (
                 <div key={id} ref={refs.current[index]} id={id} className="h-auto w-full bg-stone-900">
-                    <Component />
+                    {id === 'home' ? (
+                        <Component initialHomepageImages={initialHomepageImages} />
+                    ) : (
+                        <Component />
+                    )}
                 </div>
             ))}
         </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,8 @@ import type { Metadata } from 'next';
 import PageLayout from '@/components/layout/PageLayout';
 import MainView from './main_view';
 import HomePageTracking from './HomePageTracking';
+import { preloadQuery, preloadedQueryResult } from 'convex/nextjs';
+import { api } from '@/convex/_generated/api';
 
 export const metadata: Metadata = {
     title: 'Capital City Staging',
@@ -30,11 +32,27 @@ export const metadata: Metadata = {
     },
 };
 
-export default function Home() {
+export default async function Home() {
+    // Preload homepage images at SSR time so they're available instantly on the client
+    let initialHomepageImages: Array<{ imagePath: string; width: number; height: number }> | null = null;
+    try {
+        const preloaded = await preloadQuery(api.homepageImages.getHomepageImages);
+        const result = preloadedQueryResult(preloaded);
+        if (result && result.length > 0) {
+            initialHomepageImages = result.map((img: any) => ({
+                imagePath: img.imagePath,
+                width: img.width,
+                height: img.height,
+            }));
+        }
+    } catch {
+        // If preloading fails, the client will fall back to hardcoded images
+    }
+
     return (
         <PageLayout page="home">
             <HomePageTracking />
-            <MainView />
+            <MainView initialHomepageImages={initialHomepageImages} />
         </PageLayout>
     );
 }

--- a/src/lib/menu_list.ts
+++ b/src/lib/menu_list.ts
@@ -53,7 +53,15 @@ export const admin_menu_list: MenuItem[] = [
         ],
     },
     { id: 'users', label: 'Users', url: '/admin/users' },
-    { id: 'manage', label: 'Manage', url: '/admin/manage' },
+    {
+        id: 'manage',
+        label: 'Manage',
+        url: '/admin/manage',
+        subMenu: [
+            { id: 'manage-inventory', label: 'Inventory', url: '/admin/manage' },
+            { id: 'manage-homepage', label: 'Homepage', url: '/admin/manage/homepage' },
+        ],
+    },
 ];
 
 export default { navbar_menu_list, menu_list, admin_menu_list };


### PR DESCRIPTION
## Summary
- New `/admin/manage/homepage` admin page for curating the homepage hero slideshow images
- Convex `homepageImages` table + 11 backend queries/mutations for full CRUD, reordering, and batch operations
- Beautiful admin UI with live preview strip, drag-and-drop image grid, project image browser with multi-select, and upload tab
- Homepage hero now uses SSR-preloaded Convex data via `preloadQuery` for zero-delay initial render, with graceful fallback to hardcoded stock images
- Admin nav updated with Manage submenu (Inventory + Homepage)

## Test plan
- [ ] Run `npx convex dev` to push schema and verify no errors
- [ ] Visit `/admin/manage/homepage` — verify page loads with empty state
- [ ] Add images from highlighted projects — verify they appear in grid with correct ordering
- [ ] Upload a new image — verify resize, thumbnail, and addition work
- [ ] Drag-and-drop reorder images — verify order persists and live preview updates
- [ ] Toggle active/inactive — verify greyed-out styling and live preview excludes inactive
- [ ] Remove an image — verify it disappears
- [ ] Visit homepage `/` — verify hero slideshow shows admin-configured images
- [ ] With empty `homepageImages` table — verify homepage falls back to stock images
- [ ] Check responsive layout at sm/md/lg/xl breakpoints

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches both persistence (new table + ordering mutations) and homepage rendering/SSR data fetching; main risk is incorrect auth gating or ordering/empty-state handling affecting admin operations or hero image display.
> 
> **Overview**
> Adds a new admin workflow to curate homepage hero slideshow images: a `homepageImages` Convex table (with indexes) plus queries/mutations to list active/all images, add from uploads or highlighted project images (deduped), update captions/active status, remove (with displayOrder renormalization), and reorder.
> 
> Updates the public homepage hero to source images from Convex (real-time after hydration) with SSR preloading via `preloadQuery`, falling back to the existing hardcoded stock images if none are configured or preloading fails. Introduces a new `/admin/manage/homepage` page with drag-and-drop ordering, live preview, and upload/project selection UI, and adds the new page to the admin Manage submenu.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8386b8dc0595a3022982f04e0233db2b78ec2212. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->