### PR TITLE
Fix homepage admin live preview sizing

### DIFF
--- a/src/app/admin/manage/homepage/HomepageManageClient.tsx
+++ b/src/app/admin/manage/homepage/HomepageManageClient.tsx
@@ -65,7 +65,7 @@ function LivePreviewStrip({ images }: { images: HomepageImageDoc[] }) {
 
     if (images.length === 0) {
         return (
-            <div className="relative mx-4 mt-4 flex h-48 items-center justify-center overflow-hidden rounded-xl border border-stone-700 bg-stone-800/50">
+            <div className="mx-auto mt-4 flex aspect-[16/9] max-h-[350px] w-full max-w-3xl items-center justify-center overflow-hidden rounded-xl border border-stone-700 bg-stone-800/50">
                 <p className="text-sm text-stone-500">No active images to preview</p>
             </div>
         );
@@ -73,7 +73,7 @@ function LivePreviewStrip({ images }: { images: HomepageImageDoc[] }) {
 
     return (
         <div
-            className="relative mx-4 mt-4 h-48 overflow-hidden rounded-xl border border-stone-700"
+            className="relative mx-auto mt-4 aspect-[16/9] max-h-[350px] w-full max-w-3xl overflow-hidden rounded-xl border border-stone-700"
             onMouseEnter={() => setIsPaused(true)}
             onMouseLeave={() => setIsPaused(false)}
         >


### PR DESCRIPTION
## Summary
- Live preview strip was too short (`h-48` / 192px) and full-width, causing images to appear stretched
- Now uses `aspect-[16/9]` with `max-w-3xl` centered and `max-h-[350px]` for a proper miniature hero preview

## Test plan
- [ ] Visit `/admin/manage/homepage` and verify the live preview is properly proportioned
- [ ] Check responsive behavior at different breakpoints

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Purely presentational Tailwind class changes to the admin preview container; no data flow or business logic changes.
> 
> **Overview**
> Improves the `/admin/manage/homepage` **live preview** sizing so hero images render with correct proportions.
> 
> The preview container is changed from a fixed `h-48` full-width strip to a centered `aspect-[16/9]` frame with `max-w-3xl` and `max-h-[350px]`, applied consistently for both the empty state and the animated slideshow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 69fab2f747868832a17067ef0eac732149136611. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->