### PR TITLE
Stage project photos before they are committed

### DIFF
--- a/convex/projects.ts
+++ b/convex/projects.ts
@@ -258,6 +258,78 @@ export const addProjectImage = mutation({
 });
 
 // Delete project image
+/**
+ * Commit a whole batch of uploaded images in one transaction.
+ *
+ * The old flow inserted each image the moment it finished uploading, one mutation per file, so a
+ * ten-image drop was ten separate writes with no way to reorder, retitle, or back out of any of them
+ * first. Here nothing is written until she submits, and then it is all written or none of it is.
+ */
+export const addProjectImages = mutation({
+  args: {
+    projectId: v.id("projects"),
+    images: v.array(
+      v.object({
+        title: v.optional(v.string()),
+        imagePath: v.string(),
+        width: v.number(),
+        height: v.number(),
+        thumbnailPath: v.optional(v.string()),
+        thumbnailWidth: v.optional(v.number()),
+        thumbnailHeight: v.optional(v.number()),
+      }),
+    ),
+  },
+  handler: async (ctx, args) => {
+    const admin = await requireAdmin(ctx);
+
+    const project = await ctx.db.get(args.projectId);
+    if (!project) throw new Error("Project not found");
+
+    /* New images land after whatever is already there, in the order she arranged them. */
+    const existing = await ctx.db
+      .query("projectImages")
+      .withIndex("by_project", (q) => q.eq("projectId", args.projectId))
+      .collect();
+    const start = existing.reduce((highest, row) => Math.max(highest, row.displayOrder + 1), 0);
+
+    const ids = [];
+    for (const [index, image] of args.images.entries()) {
+      ids.push(
+        await ctx.db.insert("projectImages", {
+          projectId: args.projectId,
+          ownerId: admin.clerkId,
+          title: image.title?.trim() || undefined,
+          imagePath: image.imagePath,
+          width: image.width,
+          height: image.height,
+          thumbnailPath: image.thumbnailPath,
+          thumbnailWidth: image.thumbnailWidth,
+          thumbnailHeight: image.thumbnailHeight,
+          displayOrder: start + index,
+          createdAt: Date.now(),
+        }),
+      );
+    }
+
+    return { added: ids.length, ids };
+  },
+});
+
+/** Retitle an image that is already on the project. */
+export const updateProjectImage = mutation({
+  args: { imageId: v.id("projectImages"), title: v.string() },
+  handler: async (ctx, args) => {
+    await requireAdmin(ctx);
+
+    const image = await ctx.db.get(args.imageId);
+    if (!image) throw new Error("Image not found");
+
+    await ctx.db.patch(args.imageId, { title: args.title.trim() || undefined });
+    return { success: true };
+  },
+});
+
 export const deleteProjectImage = mutation({
   args: { id: v.id("projectImages") },
   handler: async (ctx, args) => {

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -86,6 +86,8 @@ export default defineSchema({
   projectImages: defineTable({
     projectId: v.id("projects"),
     ownerId: v.string(),
+    /* Caption shown under the photo and used as its alt text. Optional: existing rows predate it. */
+    title: v.optional(v.string()),
     imagePath: v.string(),
     width: v.number(),
     height: v.number(),

--- a/src/app/_main_components/PortfolioLightbox.tsx
+++ b/src/app/_main_components/PortfolioLightbox.tsx
@@ -6,6 +6,8 @@ import { ChevronLeft, ChevronRight, X } from 'lucide-react';
 
 interface LightboxImage {
     _id: string;
+    /** Caption written on the project; describes the room better than an index can. */
+    title?: string;
     imagePath: string;
     width: number;
     height: number;
@@ -63,7 +65,7 @@ export default function PortfolioLightbox({ images, index, projectName, onClose,
             <Image
                 key={image._id}
                 src={image.imagePath}
-                alt={`${projectName}, image ${index + 1}`}
+                alt={image.title ?? `${projectName}, image ${index + 1}`}
                 width={image.width}
                 height={image.height}
                 sizes="90vw"

--- a/src/app/_main_components/about.tsx
+++ b/src/app/_main_components/about.tsx
@@ -33,34 +33,38 @@ export default function About() {
                             className="bg-body h-9 w-auto shrink-0 rounded p-1"
                         />
                         <p className="text-body-subtle text-xs leading-snug">
-                            Certified through the{' '}
                             <Link
                                 href="https://www.realestatestagingassociation.com/"
                                 className="text-gold-300 hover:text-gold-200 font-semibold"
                             >
-                                Real Estate Staging Association
+                                RESA Certified Professional Home Stager
                             </Link>
                         </p>
                     </div>
                 </div>
 
                 <div>
-                    <p className="text-forest-200 text-xs font-bold tracking-[0.2em] uppercase">Who you&rsquo;ll work with</p>
-                    <h2 className="font-display gradient-gold-main-text mt-3 text-3xl font-bold sm:text-4xl">Mia Dofflemyer</h2>
+                    <h2 className="font-display gradient-gold-main-text text-3xl font-bold sm:text-4xl">Mia Dofflemyer</h2>
                     <p className="text-body-muted mt-1.5">Founder, Capital City Staging</p>
-                    <p className="text-body-subtle text-sm">Licensed California real estate agent since 2020</p>
+                    <p className="text-body-subtle text-sm">Licensed Real Estate Professional &bull; Home Staging Expert</p>
 
                     <div className="text-body-muted mt-6 space-y-4">
                         <p>
-                            I grew up in the valley, studied at UC Davis, and have spent the years since helping people in Sacramento buy
-                            and sell homes. Staging is the part I kept coming back to &mdash; it&rsquo;s what most reliably changes the
-                            outcome.
+                            Hello! I&rsquo;m Mia Dofflemyer, the founder of Capital City Staging. Raised in the valley and educated at UC
+                            Davis, I later settled in Sacramento to pursue my passion for real estate.
                         </p>
                         <p>
-                            Selling a house is a transaction to everyone except the person who lived in it. I stage for the buyer&rsquo;s
-                            first impression without forgetting whose home it still is.
+                            Obtaining my license in 2020, I&rsquo;ve dedicated myself to assisting individuals in buying and selling homes
+                            ever since. My journey into real estate was driven by my love for home design and helping others.
                         </p>
-                        <p>You deal with me directly, from walkthrough to pickup. No account manager, no handoff.</p>
+                        <p>
+                            Through my experiences, I&rsquo;ve come to understand the crucial role that home staging plays in the selling
+                            process. With my combined passion for real estate and design, founding a staging business felt like a natural
+                            progression.
+                        </p>
+                        <p className="text-gold-300 font-semibold">
+                            Let me elevate the appeal of your home with my staging expertise, ensuring a swift sale at top value!
+                        </p>
                     </div>
 
                     <div className="border-line mt-7 flex flex-wrap items-center gap-x-6 gap-y-3 border-t pt-6">
@@ -86,9 +90,9 @@ export default function About() {
                         <Link
                             href="/contact"
                             className={PRIMARY_ACTION}
-                            onClick={() => track('cta_clicked', { cta: 'get_a_quote', placement: 'about' })}
+                            onClick={() => track('cta_clicked', { cta: 'send_a_message', placement: 'about' })}
                         >
-                            Get a free quote
+                            Send me a message
                             <ArrowRight size={16} aria-hidden="true" />
                         </Link>
                     </div>

--- a/src/app/_main_components/portfolio.tsx
+++ b/src/app/_main_components/portfolio.tsx
@@ -96,12 +96,17 @@ export default function Portfolio() {
                                     setLightboxIndex(index);
                                     track('portfolio_image_opened', { project: currentProject?.name ?? '', index });
                                 }}
-                                aria-label={`View ${currentProject?.name} image ${index + 1} full size`}
+                                aria-label={
+                                    image.title
+                                        ? `View ${image.title} full size`
+                                        : `View ${currentProject?.name} image ${index + 1} full size`
+                                }
                                 className="group border-line bg-surface-raised shadow-card relative aspect-[4/3] overflow-hidden rounded-lg border"
                             >
                                 <Image
                                     src={image.thumbnailPath || image.imagePath}
-                                    alt={`${currentProject?.name}, image ${index + 1}`}
+                                    /* Captions written on the project become the alt text, since they describe the room. */
+                                    alt={image.title ?? `${currentProject?.name}, image ${index + 1}`}
                                     fill
                                     sizes="(min-width: 1024px) 33vw, (min-width: 640px) 50vw, 100vw"
                                     className="object-cover transition-transform duration-500 group-hover:scale-[1.04]"

--- a/src/app/admin/projects/[id]/edit/EditProjectClient.tsx
+++ b/src/app/admin/projects/[id]/edit/EditProjectClient.tsx
@@ -1,33 +1,47 @@
 'use client';
 
-import { useState, useEffect } from 'react';
-import { useQuery, useMutation } from 'convex/react';
-import { api } from '@/convex/_generated/api';
-import { useRouter } from 'next/navigation';
-import ProjectResizeUploader from '@/components/ProjectResizeUploader';
-import { Id } from '@/convex/_generated/dataModel';
-import { Plus, Bell, Loader2 } from 'lucide-react';
+import { useState } from 'react';
+import { useMutation, useQuery } from 'convex/react';
 import { useUser } from '@clerk/nextjs';
+import Link from 'next/link';
+import { ArrowLeft, Images, ListChecks, MapPin, SlidersHorizontal } from 'lucide-react';
 
+import { api } from '@/convex/_generated/api';
+import type { Id } from '@/convex/_generated/dataModel';
 import CheckInDialog from './CheckInDialog';
+import ProjectDetailsForm from './ProjectDetailsForm';
+import ProjectImagesSection from './ProjectImagesSection';
 import ProjectInventoryTab from './ProjectInventoryTab';
-import { CLOSING_STATUSES, type ProjectAssignmentLine, type ProjectStatus } from './project.types';
+import type { CommittedImage } from './images.types';
+import { CLOSING_STATUSES, type ProjectAssignmentLine, type ProjectFormState, type ProjectStatus } from './project.types';
 
-interface UploadedImage {
-    fileName: string;
-    originalImageUrl: string;
-    smallImageUrl: string;
-    originalWidth: number;
-    originalHeight: number;
-    smallWidth: number;
-    smallHeight: number;
-}
+/**
+ * Editing one project.
+ *
+ * This was three tabs, which meant the photos and the furniture on the job were each one click away
+ * from being forgotten, and saving from the Details tab navigated the whole page away. Everything is
+ * on one column now; the header carries the save and a jump link per section, and saving stays put so
+ * a save in the middle of arranging photos does not throw the arrangement away.
+ */
+
+const DETAILS_FORM_ID = 'project-details-form';
+
+const SECTIONS = [
+    { id: 'details', label: 'Details', icon: SlidersHorizontal },
+    { id: 'photos', label: 'Photos', icon: Images },
+    { id: 'inventory', label: 'Inventory', icon: ListChecks },
+] as const;
+
+const STATUS_TONES: Record<ProjectStatus, string> = {
+    draft: 'border-line text-body-muted',
+    active: 'border-success/40 bg-success-soft text-success',
+    completed: 'border-line-strong text-body-subtle',
+    cancelled: 'border-danger/40 bg-danger-soft text-danger',
+};
 
 export default function EditProjectClient({ projectId }: { projectId: string }) {
-    const router = useRouter();
     const { user, isLoaded } = useUser();
 
-    // All hooks must be called at the top level before any conditional returns
     const project = useQuery(api.projects.getProjectById, isLoaded && user ? { projectId: projectId as Id<'projects'> } : 'skip');
     const assignments = useQuery(
         api.assignments.getProjectAssignments,
@@ -35,13 +49,10 @@ export default function EditProjectClient({ projectId }: { projectId: string }) 
     );
 
     const updateProject = useMutation(api.projects.updateProject);
-    const addProjectImage = useMutation(api.projects.addProjectImage);
-    const removeProjectImage = useMutation(api.projects.removeProjectImage);
-    const reorderProjectImages = useMutation(api.projects.reorderProjectImages);
 
-    const [formData, setFormData] = useState({
+    const [formData, setFormData] = useState<ProjectFormState>({
         name: '',
-        status: 'draft' as ProjectStatus,
+        status: 'draft',
         address: '',
         startDate: '',
         endDate: '',
@@ -50,98 +61,39 @@ export default function EditProjectClient({ projectId }: { projectId: string }) 
         highlighted: false,
     });
 
-    const [, setUploadedImages] = useState<UploadedImage[]>([]);
-    const [isSubmitting, setIsSubmitting] = useState(false);
-    const [draggedImageIndex, setDraggedImageIndex] = useState<number | null>(null);
-    const [isUploadingImages, setIsUploadingImages] = useState(false);
-
-    // Tab state
-    const [activeTab, setActiveTab] = useState<'details' | 'images' | 'inventory'>('details');
+    const [saving, setSaving] = useState(false);
+    const [saved, setSaved] = useState(false);
     const [saveError, setSaveError] = useState<string | null>(null);
     /* Held while the check-in dialog is open, so submitting again can carry the confirmed ids. */
     const [pendingCheckIn, setPendingCheckIn] = useState<'completed' | 'cancelled' | null>(null);
 
-    useEffect(() => {
-        if (project) {
-            setFormData({
-                name: project.name || '',
-                /*
-                 * This used to force every non-draft project back to 'draft' when the form loaded, so
-                 * opening a completed job and saving it silently reopened it.
-                 */
-                status: project.status ?? 'draft',
-                address: project.address || '',
-                startDate: project.startDate ? new Date(project.startDate).toISOString().split('T')[0] : '',
-                endDate: project.endDate ? new Date(project.endDate).toISOString().split('T')[0] : '',
-                revenue: project.revenue ? project.revenue.toString() : '',
-                notes: project.notes || '',
-                highlighted: project.highlighted || false,
-            });
-        }
-    }, [project]);
-
-    const handleUploadComplete = async (images: UploadedImage[]) => {
-        setIsUploadingImages(true);
-        setUploadedImages((prev) => [...prev, ...images]);
-
-        try {
-            // Add images to project
-            for (let i = 0; i < images.length; i++) {
-                const image = images[i];
-                const currentImageCount = (project?.images?.length || 0) + i;
-                await addProjectImage({
-                    projectId: projectId as Id<'projects'>,
-                    imagePath: image.originalImageUrl,
-                    width: image.originalWidth,
-                    height: image.originalHeight,
-                    thumbnailPath: image.smallImageUrl,
-                    thumbnailWidth: image.smallWidth,
-                    thumbnailHeight: image.smallHeight,
-                    displayOrder: currentImageCount,
-                });
-            }
-        } finally {
-            setIsUploadingImages(false);
-        }
-    };
-
-    const handleResetImages = () => {
-        setUploadedImages([]);
-    };
-
-    const handleRemoveImage = async (imageId: string) => {
-        await removeProjectImage({ imageId: imageId as Id<'projectImages'> });
-    };
-
-    const handleDragStart = (index: number) => {
-        setDraggedImageIndex(index);
-    };
-
-    const handleDragOver = (e: React.DragEvent) => {
-        e.preventDefault();
-    };
-
-    const handleDrop = async (e: React.DragEvent, dropIndex: number) => {
-        e.preventDefault();
-        if (draggedImageIndex === null || draggedImageIndex === dropIndex || !project?.images) return;
-
-        const newOrder = [...project.images];
-        const draggedImage = newOrder[draggedImageIndex];
-        newOrder.splice(draggedImageIndex, 1);
-        newOrder.splice(dropIndex, 0, draggedImage);
-
-        // Update display order in database
-        const imageIds = newOrder.map((img) => img._id);
-        await reorderProjectImages({
-            projectId: projectId as Id<'projects'>,
-            imageIds: imageIds as Id<'projectImages'>[],
+    /*
+     * Seeded from the query the first time a project arrives, adjusted during render rather than in an
+     * effect. Keying on the id matters: this is a live subscription, so it re-emits after every save and
+     * after every photo edit, and the effect this replaced re-seeded the form each time — typing into a
+     * field while an upload landed lost the edit.
+     */
+    const [seededFor, setSeededFor] = useState<string | null>(null);
+    if (project && seededFor !== project._id) {
+        setSeededFor(project._id);
+        setFormData({
+            name: project.name || '',
+            /*
+             * This used to force every non-draft project back to 'draft' when the form loaded, so
+             * opening a completed job and saving it silently reopened it.
+             */
+            status: (project.status as ProjectStatus) ?? 'draft',
+            address: project.address || '',
+            startDate: project.startDate ? new Date(project.startDate).toISOString().split('T')[0] : '',
+            endDate: project.endDate ? new Date(project.endDate).toISOString().split('T')[0] : '',
+            revenue: project.revenue ? project.revenue.toString() : '',
+            notes: project.notes || '',
+            highlighted: project.highlighted || false,
         });
-
-        setDraggedImageIndex(null);
-    };
+    }
 
     const save = async (checkInAssignmentIds?: string[]) => {
-        setIsSubmitting(true);
+        setSaving(true);
         setSaveError(null);
 
         try {
@@ -158,12 +110,13 @@ export default function EditProjectClient({ projectId }: { projectId: string }) 
                 checkInAssignmentIds: checkInAssignmentIds?.length ? (checkInAssignmentIds as Id<'projectInventory'>[]) : undefined,
             });
 
-            router.push('/admin/projects');
+            setPendingCheckIn(null);
+            setSaved(true);
         } catch (error) {
             setSaveError(error instanceof Error ? error.message : 'Could not save this project. Try again.');
             setPendingCheckIn(null);
         } finally {
-            setIsSubmitting(false);
+            setSaving(false);
         }
     };
 
@@ -173,8 +126,8 @@ export default function EditProjectClient({ projectId }: { projectId: string }) 
      * it — the dialog offers a way through either way — but it stops the job from quietly closing
      * while the catalog still believes the furniture is unavailable.
      */
-    const handleSubmit = (e: React.FormEvent) => {
-        e.preventDefault();
+    const handleSubmit = (event: React.FormEvent) => {
+        event.preventDefault();
 
         const closing = CLOSING_STATUSES.includes(formData.status);
         const stillOut = assignments?.open ?? [];
@@ -187,301 +140,122 @@ export default function EditProjectClient({ projectId }: { projectId: string }) 
         void save();
     };
 
-    // Show loading while user auth is loading
-    if (!isLoaded) {
-        return (
-            <div className="flex min-h-screen items-center justify-center">
-                <div className="text-body-muted">Loading...</div>
-            </div>
-        );
+    if (!isLoaded || project === undefined) {
+        return <p className="text-body-muted p-6 text-sm">Loading project…</p>;
     }
 
-    // Redirect to login if not authenticated
     if (!user) {
-        router.push('/sign-in');
         return (
-            <div className="flex min-h-screen items-center justify-center">
-                <div className="text-body-muted">Redirecting to login...</div>
-            </div>
+            <p className="text-body-muted p-6 text-sm">
+                <Link href="/sign-in" className="text-gold-300 hover:text-gold-200 font-bold">
+                    Sign in
+                </Link>{' '}
+                to edit this project.
+            </p>
         );
     }
 
-    // Show loading while project data is loading
-    if (project === undefined) {
-        return (
-            <div className="flex min-h-screen items-center justify-center">
-                <div className="text-body-muted">Loading project...</div>
-            </div>
-        );
-    }
-
-    // Show not found if project doesn't exist
     if (project === null) {
         return (
-            <div className="flex min-h-screen items-center justify-center">
-                <div className="text-body-muted">Project not found</div>
+            <div className="flex flex-col gap-3 p-6">
+                <p className="text-body text-sm font-bold">That project no longer exists.</p>
+                <Link href="/admin/projects" className="text-gold-300 hover:text-gold-200 text-sm font-bold">
+                    Back to projects
+                </Link>
             </div>
         );
     }
 
+    const images = (project.images ?? []) as CommittedImage[];
+    const openCount = assignments?.open.length ?? 0;
+    const counts: Record<(typeof SECTIONS)[number]['id'], number | null> = {
+        details: null,
+        photos: images.length,
+        inventory: openCount,
+    };
+
     return (
-        <div className="container mx-auto max-w-5xl p-4">
-            {/* Tab Navigation */}
-            <div className="bg-surface-raised mb-6 flex space-x-1 rounded-lg p-1">
-                <button
-                    type="button"
-                    onClick={() => setActiveTab('details')}
-                    className={`flex-1 rounded-md px-3 py-2 text-sm font-medium transition-colors ${
-                        activeTab === 'details' ? 'bg-primary text-white' : 'text-body-subtle hover:text-body'
-                    }`}
-                >
-                    Details
-                </button>
-                <button
-                    type="button"
-                    onClick={() => setActiveTab('images')}
-                    className={`flex-1 rounded-md px-3 py-2 text-sm font-medium transition-colors ${
-                        activeTab === 'images' ? 'bg-primary text-white' : 'text-body-subtle hover:text-body'
-                    }`}
-                >
-                    Images {project.images && project.images.length > 0 && <span className="ml-1 text-xs">({project.images.length})</span>}
-                </button>
-                <button
-                    type="button"
-                    onClick={() => setActiveTab('inventory')}
-                    className={`flex-1 rounded-md px-3 py-2 text-sm font-medium transition-colors ${
-                        activeTab === 'inventory' ? 'bg-primary text-white' : 'text-body-subtle hover:text-body'
-                    }`}
-                >
-                    Inventory{' '}
-                    {assignments && assignments.open.length > 0 && <span className="ml-1 text-xs">({assignments.open.length})</span>}
-                </button>
-            </div>
+        <div className="mx-auto flex max-w-5xl flex-col gap-5 p-4">
+            <header className="bg-ink/95 border-line sticky top-0 z-20 -mx-4 flex flex-col gap-3 border-b px-4 py-3 backdrop-blur">
+                <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
+                    <Link
+                        href="/admin/projects"
+                        className="text-body-subtle hover:text-body inline-flex items-center gap-1.5 text-xs font-bold transition-colors"
+                    >
+                        <ArrowLeft size={13} aria-hidden="true" /> Projects
+                    </Link>
 
-            {/* Tab Content */}
-            <div className="bg-surface-raised rounded-lg">
-                {activeTab === 'details' && (
-                    <form onSubmit={handleSubmit} className="p-6">
-                        <h2 className="text-body mb-6 text-2xl font-bold">Project Details</h2>
-                        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-                            <div>
-                                <label className="text-body mb-1 block text-sm font-medium">Project Name *</label>
-                                <input
-                                    type="text"
-                                    required
-                                    value={formData.name}
-                                    onChange={(e) => setFormData({ ...formData, name: e.target.value })}
-                                    className="border-line-strong bg-surface-overlay text-body focus:border-primary w-full rounded border px-3 py-2 focus:outline-none"
-                                    placeholder="Enter project name"
-                                />
-                            </div>
-
-                            <div>
-                                <label className="text-body mb-1 block text-sm font-medium">Status *</label>
-                                <select
-                                    value={formData.status}
-                                    onChange={(e) => setFormData({ ...formData, status: e.target.value as any })}
-                                    className="border-line-strong bg-surface-overlay text-body focus:border-primary w-full rounded border px-3 py-2 focus:outline-none"
-                                >
-                                    <option value="draft">Draft</option>
-                                    <option value="active">Active</option>
-                                    <option value="completed">Completed</option>
-                                    <option value="cancelled">Cancelled</option>
-                                </select>
-                            </div>
-
-                            <div className="md:col-span-2">
-                                <label className="text-body mb-1 block text-sm font-medium">Address</label>
-                                <input
-                                    type="text"
-                                    value={formData.address}
-                                    onChange={(e) => setFormData({ ...formData, address: e.target.value })}
-                                    className="border-line-strong bg-surface-overlay text-body focus:border-primary w-full rounded border px-3 py-2 focus:outline-none"
-                                    placeholder="Project address"
-                                />
-                            </div>
-
-                            <div>
-                                <label className="text-body mb-1 block text-sm font-medium">Start Date</label>
-                                <input
-                                    type="date"
-                                    value={formData.startDate}
-                                    onChange={(e) => setFormData({ ...formData, startDate: e.target.value })}
-                                    className="border-line-strong bg-surface-overlay text-body focus:border-primary w-full rounded border px-3 py-2 focus:outline-none"
-                                />
-                            </div>
-
-                            <div>
-                                <label className="text-body mb-1 block text-sm font-medium">End Date</label>
-                                <input
-                                    type="date"
-                                    value={formData.endDate}
-                                    onChange={(e) => setFormData({ ...formData, endDate: e.target.value })}
-                                    className="border-line-strong bg-surface-overlay text-body focus:border-primary w-full rounded border px-3 py-2 focus:outline-none"
-                                />
-                            </div>
-
-                            <div className="md:col-span-2">
-                                <label className="text-body mb-1 block text-sm font-medium">Revenue ($)</label>
-                                <input
-                                    type="number"
-                                    step="0.01"
-                                    value={formData.revenue}
-                                    onChange={(e) => setFormData({ ...formData, revenue: e.target.value })}
-                                    className="border-line-strong bg-surface-overlay text-body focus:border-primary w-full rounded border px-3 py-2 focus:outline-none"
-                                    placeholder="Project revenue"
-                                />
-                            </div>
-
-                            <div className="md:col-span-2">
-                                <label className="text-body mb-1 block text-sm font-medium">Notes</label>
-                                <textarea
-                                    value={formData.notes}
-                                    onChange={(e) => setFormData({ ...formData, notes: e.target.value })}
-                                    rows={3}
-                                    className="border-line-strong bg-surface-overlay text-body focus:border-primary w-full rounded border px-3 py-2 focus:outline-none"
-                                    placeholder="Project notes..."
-                                />
-                            </div>
-
-                            {saveError && (
-                                <p
-                                    role="alert"
-                                    className="border-danger/40 bg-danger-soft text-danger rounded-md border px-4 py-2.5 text-sm md:col-span-2"
-                                >
-                                    {saveError}
-                                </p>
-                            )}
-
-                            <div className="md:col-span-2">
-                                <div className="flex items-center justify-between">
-                                    <button
-                                        type="submit"
-                                        disabled={isSubmitting}
-                                        className={`rounded px-4 py-2 font-medium transition-colors ${
-                                            isSubmitting
-                                                ? 'bg-surface-hover text-body-subtle cursor-not-allowed'
-                                                : 'bg-primary hover:bg-primary_dark text-white'
-                                        }`}
-                                    >
-                                        {isSubmitting ? 'Saving...' : 'Save Project'}
-                                    </button>
-                                    <div className="flex items-center">
-                                        <input
-                                            type="checkbox"
-                                            id="highlighted"
-                                            checked={formData.highlighted}
-                                            onChange={(e) => setFormData({ ...formData, highlighted: e.target.checked })}
-                                            className="border-line-strong bg-surface-overlay text-primary focus:ring-primary mr-2 h-4 w-4 rounded focus:ring-2"
-                                        />
-                                        <label htmlFor="highlighted" className="text-body text-sm font-medium">
-                                            Show in portfolio (highlighted)
-                                        </label>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </form>
-                )}
-
-                {activeTab === 'images' && (
-                    <div className="p-6">
-                        <div className="mb-6 flex items-center justify-between">
-                            <h2 className="text-body text-2xl font-bold">Project Images</h2>
-                            <button
-                                type="button"
-                                onClick={() => {
-                                    const uploadInput = document.querySelector('#project-uploader input') as HTMLInputElement;
-                                    if (uploadInput) uploadInput.click();
-                                }}
-                                disabled={isUploadingImages}
-                                className={`flex h-8 w-8 items-center justify-center rounded-lg border transition-colors ${
-                                    isUploadingImages
-                                        ? 'border-line-strong bg-surface-hover text-body-subtle cursor-not-allowed'
-                                        : 'border-primary text-primary hover:border-secondary hover:bg-secondary hover:text-body-muted bg-transparent'
-                                }`}
-                                title={isUploadingImages ? 'Processing images...' : 'Add images'}
-                            >
-                                {isUploadingImages ? <Loader2 className="animate-spin" size={16} /> : <Plus size={16} />}
-                            </button>
-                        </div>
-
-                        <div className="space-y-4">
-                            {/* Hidden ProjectResizeUploader */}
-                            <div id="project-uploader" className="hidden">
-                                <ProjectResizeUploader
-                                    onUploadComplete={handleUploadComplete}
-                                    onResetInputs={handleResetImages}
-                                    disabled={isSubmitting}
-                                />
-                            </div>
-
-                            {/* Upload Loading Spinner */}
-                            {isUploadingImages && (
-                                <div className="flex items-center justify-center py-8">
-                                    <div className="bg-surface-overlay flex items-center gap-3 rounded-lg px-4 py-3">
-                                        <Loader2 className="text-primary h-5 w-5 animate-spin" />
-                                        <span className="text-body text-sm">Processing uploaded images...</span>
-                                    </div>
-                                </div>
-                            )}
-
-                            {/* Existing Images */}
-                            {project.images && project.images.length > 0 && (
-                                <div>
-                                    <div className="text-body-inverse mb-3 flex items-center gap-2 rounded-lg bg-green-300/70 p-2">
-                                        <Bell size={16} />
-                                        <span className="text-sm">Drag and drop to reorder</span>
-                                    </div>
-                                    <div className="max-h-120 overflow-y-auto">
-                                        <div className="grid grid-cols-2 gap-4 pr-2 md:grid-cols-3 lg:grid-cols-4">
-                                            {project.images.map((image, index) => (
-                                                <div
-                                                    key={image._id}
-                                                    className="group relative cursor-move"
-                                                    draggable
-                                                    onDragStart={() => handleDragStart(index)}
-                                                    onDragOver={handleDragOver}
-                                                    onDrop={(e) => handleDrop(e, index)}
-                                                >
-                                                    <img
-                                                        src={image.thumbnailPath || image.imagePath}
-                                                        alt={`Project image ${index + 1}`}
-                                                        className="aspect-square w-full rounded-lg object-cover"
-                                                    />
-                                                    <button
-                                                        type="button"
-                                                        onClick={() => handleRemoveImage(image._id)}
-                                                        className="absolute top-2 right-2 flex h-6 w-6 items-center justify-center rounded-full bg-red-600 text-white opacity-0 transition-opacity group-hover:opacity-100"
-                                                    >
-                                                        ×
-                                                    </button>
-                                                    <div className="absolute bottom-2 left-2 rounded bg-black/60 px-2 py-1 text-xs text-white">
-                                                        {index + 1}
-                                                    </div>
-                                                </div>
-                                            ))}
-                                        </div>
-                                    </div>
-                                </div>
-                            )}
-                        </div>
+                    <div className="flex min-w-0 flex-col">
+                        <h1 className="font-display text-body truncate text-xl leading-tight font-normal">
+                            {formData.name || project.name || 'Untitled project'}
+                        </h1>
+                        {formData.address && (
+                            <span className="text-body-subtle inline-flex items-center gap-1 truncate text-xs">
+                                <MapPin size={11} aria-hidden="true" /> {formData.address}
+                            </span>
+                        )}
                     </div>
-                )}
 
-                {activeTab === 'inventory' && (
-                    <div className="p-6">
-                        <ProjectInventoryTab projectId={projectId} />
-                    </div>
-                )}
-            </div>
+                    <span className={`rounded-full border px-2.5 py-1 text-[11px] font-bold capitalize ${STATUS_TONES[formData.status]}`}>
+                        {formData.status}
+                    </span>
+
+                    <button
+                        type="submit"
+                        form={DETAILS_FORM_ID}
+                        disabled={saving}
+                        className="bg-gold-400 text-body-inverse hover:bg-gold-300 ml-auto rounded-md px-4 py-2 text-sm font-bold transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                        {saving ? 'Saving…' : 'Save'}
+                    </button>
+                </div>
+
+                <nav aria-label="Sections" className="flex flex-wrap gap-1.5">
+                    {SECTIONS.map((section) => (
+                        <a
+                            key={section.id}
+                            href={`#${section.id}`}
+                            className="border-line text-body-muted hover:bg-surface-hover hover:text-body inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-xs font-bold transition-colors"
+                        >
+                            <section.icon size={12} aria-hidden="true" />
+                            {section.label}
+                            {counts[section.id] !== null && counts[section.id]! > 0 && (
+                                <span className="text-body-subtle">{counts[section.id]}</span>
+                            )}
+                        </a>
+                    ))}
+                </nav>
+            </header>
+
+            <section id="details" className="scroll-mt-32">
+                <ProjectDetailsForm
+                    formId={DETAILS_FORM_ID}
+                    formData={formData}
+                    onChange={(patch) => {
+                        setSaved(false);
+                        setFormData((current) => ({ ...current, ...patch }));
+                    }}
+                    onSubmit={handleSubmit}
+                    saving={saving}
+                    error={saveError}
+                    saved={saved}
+                />
+            </section>
+
+            <section id="photos" className="scroll-mt-32">
+                <ProjectImagesSection projectId={projectId} images={images} />
+            </section>
+
+            <section id="inventory" className="scroll-mt-32">
+                <ProjectInventoryTab projectId={projectId} />
+            </section>
 
             {pendingCheckIn && (
                 <CheckInDialog
                     projectName={project.name}
                     status={pendingCheckIn}
                     lines={(assignments?.open ?? []) as ProjectAssignmentLine[]}
-                    saving={isSubmitting}
+                    saving={saving}
                     onCancel={() => setPendingCheckIn(null)}
                     onConfirm={(checkInIds) => void save(checkInIds)}
                 />

--- a/src/app/admin/projects/[id]/edit/ProjectDetailsForm.tsx
+++ b/src/app/admin/projects/[id]/edit/ProjectDetailsForm.tsx
@@ -1,0 +1,185 @@
+'use client';
+
+import { CheckCircle2, Loader2, Star } from 'lucide-react';
+
+import { AdminPanel } from '@/components/admin/AdminPrimitives';
+
+import type { ProjectFormState, ProjectStatus } from './project.types';
+
+/**
+ * The written record of a job: what it is called, where it is, what it earned.
+ *
+ * The form id is deliberate — the save button lives in the page header so it is reachable from any
+ * section, and a submit button outside a form is only wired to it by `form="…"`.
+ */
+
+const FIELD =
+    'border-line bg-surface text-body placeholder:text-body-subtle focus-visible:border-gold-300 w-full rounded-md border px-3 py-2.5 text-sm outline-none transition-colors';
+const LABEL = 'text-body-muted text-xs font-bold';
+
+const STATUS_OPTIONS: { value: ProjectStatus; label: string; hint: string }[] = [
+    { value: 'draft', label: 'Draft', hint: 'Not started yet' },
+    { value: 'active', label: 'Active', hint: 'Furniture is on site' },
+    { value: 'completed', label: 'Completed', hint: 'Closes the job and prompts a check-in' },
+    { value: 'cancelled', label: 'Cancelled', hint: 'Closes the job and prompts a check-in' },
+];
+
+export default function ProjectDetailsForm({
+    formId,
+    formData,
+    onChange,
+    onSubmit,
+    saving,
+    error,
+    saved,
+}: {
+    formId: string;
+    formData: ProjectFormState;
+    onChange: (patch: Partial<ProjectFormState>) => void;
+    onSubmit: (event: React.FormEvent) => void;
+    saving: boolean;
+    error: string | null;
+    saved: boolean;
+}) {
+    const statusHint = STATUS_OPTIONS.find((option) => option.value === formData.status)?.hint;
+
+    return (
+        <AdminPanel eyebrow="Details" title="Project details">
+            <form id={formId} onSubmit={onSubmit} className="flex flex-col gap-4 p-4">
+                <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                    <label className="flex flex-col gap-1.5 md:col-span-2">
+                        <span className={LABEL}>Project name *</span>
+                        <input
+                            type="text"
+                            required
+                            value={formData.name}
+                            onChange={(event) => onChange({ name: event.target.value })}
+                            placeholder="123 Oak Street"
+                            className={FIELD}
+                        />
+                    </label>
+
+                    <label className="flex flex-col gap-1.5">
+                        <span className={LABEL}>Status *</span>
+                        <select
+                            value={formData.status}
+                            onChange={(event) => onChange({ status: event.target.value as ProjectStatus })}
+                            className={FIELD}
+                        >
+                            {STATUS_OPTIONS.map((option) => (
+                                <option key={option.value} value={option.value}>
+                                    {option.label}
+                                </option>
+                            ))}
+                        </select>
+                        {statusHint && <span className="text-body-subtle text-xs">{statusHint}</span>}
+                    </label>
+
+                    <label className="flex flex-col gap-1.5">
+                        <span className={LABEL}>Revenue</span>
+                        <div className="relative">
+                            <span className="text-body-subtle pointer-events-none absolute top-1/2 left-3 -translate-y-1/2 text-sm">$</span>
+                            <input
+                                type="number"
+                                step="0.01"
+                                value={formData.revenue}
+                                onChange={(event) => onChange({ revenue: event.target.value })}
+                                placeholder="0.00"
+                                className={`${FIELD} pl-7`}
+                            />
+                        </div>
+                    </label>
+
+                    <label className="flex flex-col gap-1.5 md:col-span-2">
+                        <span className={LABEL}>Address</span>
+                        <input
+                            type="text"
+                            value={formData.address}
+                            onChange={(event) => onChange({ address: event.target.value })}
+                            placeholder="Street, city, state"
+                            className={FIELD}
+                        />
+                    </label>
+
+                    <label className="flex flex-col gap-1.5">
+                        <span className={LABEL}>Start date</span>
+                        <input
+                            type="date"
+                            value={formData.startDate}
+                            onChange={(event) => onChange({ startDate: event.target.value })}
+                            className={FIELD}
+                        />
+                    </label>
+
+                    <label className="flex flex-col gap-1.5">
+                        <span className={LABEL}>End date</span>
+                        <input
+                            type="date"
+                            value={formData.endDate}
+                            onChange={(event) => onChange({ endDate: event.target.value })}
+                            className={FIELD}
+                        />
+                    </label>
+
+                    <label className="flex flex-col gap-1.5 md:col-span-2">
+                        <span className={LABEL}>Notes</span>
+                        <textarea
+                            value={formData.notes}
+                            onChange={(event) => onChange({ notes: event.target.value })}
+                            rows={3}
+                            placeholder="Anything worth remembering about this job."
+                            className={`${FIELD} resize-y`}
+                        />
+                    </label>
+                </div>
+
+                <label
+                    className={`flex cursor-pointer items-start gap-3 rounded-md border px-3.5 py-3 transition-colors ${
+                        formData.highlighted ? 'border-gold-300/50 bg-gold-400/5' : 'border-line hover:bg-surface-hover'
+                    }`}
+                >
+                    <input
+                        type="checkbox"
+                        checked={formData.highlighted}
+                        onChange={(event) => onChange({ highlighted: event.target.checked })}
+                        className="accent-gold-400 mt-0.5 h-4 w-4"
+                    />
+                    <span className="flex flex-col gap-0.5">
+                        <span className="text-body inline-flex items-center gap-1.5 text-sm font-bold">
+                            <Star size={13} aria-hidden="true" className={formData.highlighted ? 'text-gold-300' : 'text-body-subtle'} />
+                            Show in the public portfolio
+                        </span>
+                        <span className="text-body-subtle text-xs">
+                            Highlighted projects appear on the portfolio page, using the first photo below.
+                        </span>
+                    </span>
+                </label>
+
+                {error && (
+                    <p role="alert" className="border-danger/40 bg-danger-soft text-danger rounded-md border px-4 py-2.5 text-sm">
+                        {error}
+                    </p>
+                )}
+
+                <div className="border-line flex flex-wrap items-center gap-3 border-t pt-4">
+                    <button
+                        type="submit"
+                        disabled={saving}
+                        className="bg-gold-400 text-body-inverse hover:bg-gold-300 inline-flex items-center gap-2 rounded-md px-4 py-2.5 text-sm font-bold transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                        {saving && <Loader2 size={15} aria-hidden="true" className="animate-spin" />}
+                        {saving ? 'Saving…' : 'Save details'}
+                    </button>
+                    <p aria-live="polite" className="empty:hidden">
+                        {saved && !saving && (
+                            <span className="text-success inline-flex items-center gap-1.5 text-sm font-bold">
+                                <CheckCircle2 size={14} aria-hidden="true" /> Saved
+                            </span>
+                        )}
+                    </p>
+                    <span className="text-body-subtle ml-auto text-xs">Photos and inventory save on their own.</span>
+                </div>
+            </form>
+        </AdminPanel>
+    );
+}

--- a/src/app/admin/projects/[id]/edit/ProjectImageCard.tsx
+++ b/src/app/admin/projects/[id]/edit/ProjectImageCard.tsx
@@ -1,0 +1,161 @@
+'use client';
+
+import Image from 'next/image';
+import { AlertCircle, Check, GripVertical, ImageOff, Loader2, MoveLeft, MoveRight, Trash2 } from 'lucide-react';
+
+import { UPLOAD_STAGE_LABELS, type PendingImage } from './images.types';
+
+/**
+ * One image, in either list.
+ *
+ * Pending and committed images differ only in when their edits land, so they are the same card. The
+ * reorder controls are buttons as well as a drag handle: drag-only ordering cannot be operated from a
+ * keyboard, and this is the control that decides what a client sees first on the public page.
+ */
+export default function ProjectImageCard({
+    src,
+    title,
+    fileName,
+    stage,
+    error,
+    position,
+    total,
+    dragging,
+    onTitleChange,
+    onTitleCommit,
+    onRemove,
+    onMove,
+    onDragStart,
+    onDragOver,
+    onDrop,
+    onDragEnd,
+}: {
+    src?: string;
+    title: string;
+    fileName?: string;
+    /** Omitted for images already on the project — those are, by definition, ready. */
+    stage?: PendingImage['stage'];
+    error?: string;
+    position: number;
+    total: number;
+    dragging?: boolean;
+    onTitleChange: (title: string) => void;
+    /** Fired on blur, for lists that write each edit straight through. */
+    onTitleCommit?: () => void;
+    onRemove: () => void;
+    onMove: (direction: -1 | 1) => void;
+    onDragStart?: () => void;
+    onDragOver?: (event: React.DragEvent) => void;
+    onDrop?: () => void;
+    onDragEnd?: () => void;
+}) {
+    const busy = stage === 'resizing' || stage === 'uploading';
+    const failed = stage === 'failed';
+
+    return (
+        <li
+            draggable={!busy}
+            onDragStart={onDragStart}
+            onDragOver={onDragOver}
+            onDrop={onDrop}
+            onDragEnd={onDragEnd}
+            className={`bg-surface-raised relative flex flex-col overflow-hidden rounded-lg border transition-colors ${
+                failed ? 'border-danger/50' : dragging ? 'border-gold-300 opacity-60' : 'border-line hover:border-line-strong'
+            }`}
+        >
+            <div className="bg-surface relative aspect-[4/3] w-full overflow-hidden">
+                {src ? (
+                    <Image
+                        src={src}
+                        alt={title || fileName || ''}
+                        fill
+                        unoptimized={src.startsWith('blob:')}
+                        className={`object-cover ${busy ? 'opacity-50' : ''}`}
+                        sizes="(max-width: 640px) 50vw, 25vw"
+                    />
+                ) : (
+                    <span className="grid h-full w-full place-items-center">
+                        <ImageOff size={20} aria-hidden="true" className="text-body-subtle" />
+                    </span>
+                )}
+
+                <span className="bg-ink/80 text-body absolute top-2 left-2 grid h-6 min-w-6 place-items-center rounded-full px-1.5 text-[11px] font-bold backdrop-blur">
+                    {position + 1}
+                </span>
+
+                {!busy && (
+                    <span
+                        aria-hidden="true"
+                        className="bg-ink/70 text-body-subtle absolute top-2 right-2 grid h-6 w-6 cursor-grab place-items-center rounded backdrop-blur active:cursor-grabbing"
+                    >
+                        <GripVertical size={13} />
+                    </span>
+                )}
+
+                {stage && stage !== 'ready' && (
+                    <span
+                        className={`absolute inset-x-0 bottom-0 flex items-center justify-center gap-1.5 px-2 py-1.5 text-[11px] font-bold backdrop-blur ${
+                            failed ? 'bg-danger-soft text-danger' : 'bg-ink/80 text-body'
+                        }`}
+                    >
+                        {failed ? (
+                            <AlertCircle size={12} aria-hidden="true" />
+                        ) : (
+                            <Loader2 size={12} aria-hidden="true" className="animate-spin" />
+                        )}
+                        {error ?? UPLOAD_STAGE_LABELS[stage]}
+                    </span>
+                )}
+
+                {stage === 'ready' && (
+                    <span className="bg-success-soft text-success absolute right-2 bottom-2 grid h-6 w-6 place-items-center rounded-full">
+                        <Check size={13} strokeWidth={3} aria-hidden="true" />
+                    </span>
+                )}
+            </div>
+
+            <div className="flex flex-col gap-2 p-2.5">
+                <label className="flex flex-col gap-1">
+                    <span className="sr-only">Caption for image {position + 1}</span>
+                    <input
+                        type="text"
+                        value={title}
+                        onChange={(event) => onTitleChange(event.target.value)}
+                        onBlur={onTitleCommit}
+                        placeholder={fileName ?? 'Add a caption'}
+                        className="border-line bg-surface text-body placeholder:text-body-subtle focus-visible:border-gold-300 w-full rounded border px-2 py-1.5 text-xs outline-none"
+                    />
+                </label>
+
+                <div className="flex items-center gap-1">
+                    <button
+                        type="button"
+                        onClick={() => onMove(-1)}
+                        disabled={position === 0}
+                        aria-label={`Move image ${position + 1} earlier`}
+                        className="border-line text-body-subtle hover:bg-surface-hover hover:text-body grid h-8 w-8 place-items-center rounded border transition-colors disabled:opacity-30"
+                    >
+                        <MoveLeft size={13} aria-hidden="true" />
+                    </button>
+                    <button
+                        type="button"
+                        onClick={() => onMove(1)}
+                        disabled={position === total - 1}
+                        aria-label={`Move image ${position + 1} later`}
+                        className="border-line text-body-subtle hover:bg-surface-hover hover:text-body grid h-8 w-8 place-items-center rounded border transition-colors disabled:opacity-30"
+                    >
+                        <MoveRight size={13} aria-hidden="true" />
+                    </button>
+                    <button
+                        type="button"
+                        onClick={onRemove}
+                        aria-label={`Remove image ${position + 1}`}
+                        className="border-line text-body-subtle hover:border-danger/50 hover:bg-danger-soft hover:text-danger ml-auto grid h-8 w-8 place-items-center rounded border transition-colors"
+                    >
+                        <Trash2 size={13} aria-hidden="true" />
+                    </button>
+                </div>
+            </div>
+        </li>
+    );
+}

--- a/src/app/admin/projects/[id]/edit/ProjectImagesSection.tsx
+++ b/src/app/admin/projects/[id]/edit/ProjectImagesSection.tsx
@@ -1,0 +1,301 @@
+'use client';
+
+import { useRef, useState } from 'react';
+import { useMutation } from 'convex/react';
+import { CheckCircle2, ImagePlus, Loader2, Upload, X } from 'lucide-react';
+
+import { api } from '@/convex/_generated/api';
+import type { Id } from '@/convex/_generated/dataModel';
+import { AdminPanel } from '@/components/admin/AdminPrimitives';
+
+import ProjectImageCard from './ProjectImageCard';
+import { useImageUpload } from './useImageUpload';
+import type { CommittedImage, PendingImage } from './images.types';
+
+/**
+ * Photos for one project, in two lists.
+ *
+ * Above: whatever she has just picked, still only in the browser. She can caption them, reorder them
+ * and drop any of them before a single row is written. Below: what is already on the project, where
+ * the same three edits apply straight away because there is nothing left to confirm.
+ *
+ * The two lists use one card. The only real difference between them is when an edit lands.
+ */
+
+function move<T>(items: T[], from: number, to: number) {
+    if (to < 0 || to >= items.length) return items;
+    const next = [...items];
+    const [lifted] = next.splice(from, 1);
+    next.splice(to, 0, lifted);
+    return next;
+}
+
+export default function ProjectImagesSection({ projectId, images }: { projectId: string; images: CommittedImage[] }) {
+    const addImages = useMutation(api.projects.addProjectImages);
+    const updateImage = useMutation(api.projects.updateProjectImage);
+    const removeImage = useMutation(api.projects.removeProjectImage);
+    const reorderImages = useMutation(api.projects.reorderProjectImages);
+
+    const fileInputRef = useRef<HTMLInputElement>(null);
+    const [pending, setPending] = useState<PendingImage[]>([]);
+    const [dragging, setDragging] = useState<{ list: 'pending' | 'committed'; index: number } | null>(null);
+    const [committing, setCommitting] = useState(false);
+    const [flash, setFlash] = useState<string | null>(null);
+    const [error, setError] = useState<string | null>(null);
+    const [dropActive, setDropActive] = useState(false);
+    /* Captions on committed images write straight through, so they are drafted here and sent on blur. */
+    const [captionDrafts, setCaptionDrafts] = useState<Record<string, string>>({});
+
+    const { upload, progress, busy } = useImageUpload(
+        (incoming) =>
+            setPending((current) => {
+                /* Re-entrant: the same keys come back with real URLs once the upload lands. */
+                const byKey = new Map(current.map((image) => [image.key, image]));
+                for (const image of incoming) {
+                    const existing = byKey.get(image.key);
+                    /* She may have captioned the card while it was uploading; the response carries a blank. */
+                    byKey.set(image.key, { ...existing, ...image, title: existing?.title || image.title });
+                }
+                return [...byKey.values()];
+            }),
+        (update) => setPending((current) => current.map((image) => (image.key === update.key ? { ...image, ...update } : image))),
+    );
+
+    const ready = pending.filter((image) => image.stage === 'ready');
+    const settled = pending.every((image) => image.stage === 'ready' || image.stage === 'failed');
+
+    const handleFiles = (files: FileList | null) => {
+        if (!files || files.length === 0) return;
+        setFlash(null);
+        setError(null);
+        void upload(files);
+    };
+
+    const handleCommit = async () => {
+        if (ready.length === 0) return;
+
+        setCommitting(true);
+        setError(null);
+        try {
+            const result = await addImages({
+                projectId: projectId as Id<'projects'>,
+                /* Committed in the order shown, so the arrangement above is what the site gets. */
+                images: pending
+                    .filter((image) => image.stage === 'ready')
+                    .map((image) => ({
+                        title: image.title.trim() || undefined,
+                        imagePath: image.imagePath as string,
+                        width: image.width as number,
+                        height: image.height as number,
+                        thumbnailPath: image.thumbnailPath,
+                        thumbnailWidth: image.thumbnailWidth,
+                        thumbnailHeight: image.thumbnailHeight,
+                    })),
+            });
+
+            for (const image of pending) if (image.previewUrl) URL.revokeObjectURL(image.previewUrl);
+            setPending([]);
+            setFlash(`${result.added} ${result.added === 1 ? 'photo' : 'photos'} added to this project.`);
+        } catch (caught) {
+            setError(caught instanceof Error ? caught.message : 'Could not save those photos.');
+        } finally {
+            setCommitting(false);
+        }
+    };
+
+    const discardPending = () => {
+        for (const image of pending) if (image.previewUrl) URL.revokeObjectURL(image.previewUrl);
+        setPending([]);
+        setError(null);
+    };
+
+    const commitOrder = (ordered: CommittedImage[]) =>
+        reorderImages({
+            projectId: projectId as Id<'projects'>,
+            imageIds: ordered.map((image) => image._id) as Id<'projectImages'>[],
+        });
+
+    return (
+        <div className="flex flex-col gap-5">
+            <AdminPanel eyebrow="Photos" title={pending.length > 0 ? `Ready to add · ${ready.length} of ${pending.length}` : 'Add photos'}>
+                <div className="p-4">
+                    <input
+                        ref={fileInputRef}
+                        type="file"
+                        multiple
+                        accept="image/*"
+                        onChange={(event) => {
+                            handleFiles(event.target.files);
+                            event.target.value = '';
+                        }}
+                        className="sr-only"
+                    />
+
+                    <div
+                        onDragOver={(event) => {
+                            event.preventDefault();
+                            setDropActive(true);
+                        }}
+                        onDragLeave={() => setDropActive(false)}
+                        onDrop={(event) => {
+                            event.preventDefault();
+                            setDropActive(false);
+                            handleFiles(event.dataTransfer.files);
+                        }}
+                        className={`flex flex-col items-center gap-3 rounded-lg border-2 border-dashed px-5 py-8 text-center transition-colors ${
+                            dropActive ? 'border-gold-300 bg-gold-400/5' : 'border-line'
+                        }`}
+                    >
+                        <ImagePlus size={24} aria-hidden="true" className="text-body-subtle" />
+                        <div className="flex flex-col gap-1">
+                            <strong className="text-body text-sm font-bold">Drop photos here</strong>
+                            <span className="text-body-muted text-xs">
+                                They stay here until you add them, so you can caption and reorder first.
+                            </span>
+                        </div>
+                        <button
+                            type="button"
+                            onClick={() => fileInputRef.current?.click()}
+                            disabled={busy}
+                            className="border-line-strong text-body hover:bg-surface-hover inline-flex items-center gap-2 rounded-md border px-4 py-2.5 text-sm font-bold transition-colors disabled:opacity-50"
+                        >
+                            {busy ? (
+                                <Loader2 size={15} aria-hidden="true" className="animate-spin" />
+                            ) : (
+                                <Upload size={15} aria-hidden="true" />
+                            )}
+                            {busy ? `Uploading… ${progress}%` : 'Choose photos'}
+                        </button>
+                    </div>
+
+                    {busy && (
+                        <div
+                            role="progressbar"
+                            aria-valuenow={progress}
+                            aria-valuemin={0}
+                            aria-valuemax={100}
+                            aria-label="Upload progress"
+                            className="bg-surface mt-3 h-1.5 w-full overflow-hidden rounded-full"
+                        >
+                            <div className="bg-gold-400 h-full transition-[width] duration-300" style={{ width: `${progress}%` }} />
+                        </div>
+                    )}
+
+                    <p aria-live="polite" className="empty:hidden">
+                        {flash && (
+                            <span className="text-success mt-3 inline-flex items-center gap-1.5 text-sm font-bold">
+                                <CheckCircle2 size={14} aria-hidden="true" /> {flash}
+                            </span>
+                        )}
+                    </p>
+                    {error && (
+                        <p role="alert" className="border-danger/40 bg-danger-soft text-danger mt-3 rounded-md border px-4 py-2.5 text-sm">
+                            {error}
+                        </p>
+                    )}
+
+                    {pending.length > 0 && (
+                        <>
+                            <ul className="mt-4 grid grid-cols-2 gap-3 sm:grid-cols-3 2xl:grid-cols-4">
+                                {pending.map((image, index) => (
+                                    <ProjectImageCard
+                                        key={image.key}
+                                        src={image.imagePath ?? image.previewUrl}
+                                        title={image.title}
+                                        fileName={image.fileName}
+                                        stage={image.stage}
+                                        error={image.error}
+                                        position={index}
+                                        total={pending.length}
+                                        dragging={dragging?.list === 'pending' && dragging.index === index}
+                                        onTitleChange={(title) =>
+                                            setPending((current) => current.map((row) => (row.key === image.key ? { ...row, title } : row)))
+                                        }
+                                        onRemove={() => {
+                                            if (image.previewUrl) URL.revokeObjectURL(image.previewUrl);
+                                            setPending((current) => current.filter((row) => row.key !== image.key));
+                                        }}
+                                        onMove={(direction) => setPending((current) => move(current, index, index + direction))}
+                                        onDragStart={() => setDragging({ list: 'pending', index })}
+                                        onDragOver={(event) => event.preventDefault()}
+                                        onDrop={() => {
+                                            if (dragging?.list !== 'pending') return;
+                                            setPending((current) => move(current, dragging.index, index));
+                                            setDragging(null);
+                                        }}
+                                        onDragEnd={() => setDragging(null)}
+                                    />
+                                ))}
+                            </ul>
+
+                            <div className="border-line mt-4 flex flex-wrap items-center gap-2 border-t pt-4">
+                                <button
+                                    type="button"
+                                    onClick={handleCommit}
+                                    disabled={committing || ready.length === 0 || !settled}
+                                    className="bg-gold-400 text-body-inverse hover:bg-gold-300 inline-flex items-center gap-2 rounded-md px-4 py-2.5 text-sm font-bold transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+                                >
+                                    {committing && <Loader2 size={15} aria-hidden="true" className="animate-spin" />}
+                                    {!settled
+                                        ? 'Waiting for uploads…'
+                                        : `Add ${ready.length} ${ready.length === 1 ? 'photo' : 'photos'} to this project`}
+                                </button>
+                                <button
+                                    type="button"
+                                    onClick={discardPending}
+                                    disabled={committing}
+                                    className="border-line text-body-muted hover:bg-surface-hover hover:text-body inline-flex items-center gap-1.5 rounded-md border px-3.5 py-2.5 text-xs font-bold transition-colors disabled:opacity-50"
+                                >
+                                    <X size={13} aria-hidden="true" /> Discard
+                                </button>
+                                <span className="text-body-subtle ml-auto text-xs">Nothing is saved until you add them.</span>
+                            </div>
+                        </>
+                    )}
+                </div>
+            </AdminPanel>
+
+            <AdminPanel eyebrow="On this project" title={images.length === 0 ? 'No photos yet' : `Photos · ${images.length}`}>
+                {images.length === 0 ? (
+                    <p className="text-body-muted px-5 py-8 text-center text-sm">
+                        Photos added here appear on the public project page, in this order.
+                    </p>
+                ) : (
+                    <>
+                        <p className="border-line text-body-subtle border-b px-4 py-2.5 text-xs">
+                            The first photo is the one the portfolio uses. Captions become the alt text on the public page.
+                        </p>
+                        <ul className="grid grid-cols-2 gap-3 p-4 sm:grid-cols-3 2xl:grid-cols-4">
+                            {images.map((image, index) => (
+                                <ProjectImageCard
+                                    key={image._id}
+                                    src={image.thumbnailPath ?? image.imagePath}
+                                    title={captionDrafts[image._id] ?? image.title ?? ''}
+                                    position={index}
+                                    total={images.length}
+                                    dragging={dragging?.list === 'committed' && dragging.index === index}
+                                    onTitleChange={(title) => setCaptionDrafts((current) => ({ ...current, [image._id]: title }))}
+                                    onTitleCommit={() => {
+                                        const draft = captionDrafts[image._id];
+                                        if (draft === undefined || draft === (image.title ?? '')) return;
+                                        void updateImage({ imageId: image._id as Id<'projectImages'>, title: draft });
+                                    }}
+                                    onRemove={() => removeImage({ imageId: image._id as Id<'projectImages'> })}
+                                    onMove={(direction) => commitOrder(move(images, index, index + direction))}
+                                    onDragStart={() => setDragging({ list: 'committed', index })}
+                                    onDragOver={(event) => event.preventDefault()}
+                                    onDrop={() => {
+                                        if (dragging?.list !== 'committed') return;
+                                        void commitOrder(move(images, dragging.index, index));
+                                        setDragging(null);
+                                    }}
+                                    onDragEnd={() => setDragging(null)}
+                                />
+                            ))}
+                        </ul>
+                    </>
+                )}
+            </AdminPanel>
+        </div>
+    );
+}

--- a/src/app/admin/projects/[id]/edit/images.types.ts
+++ b/src/app/admin/projects/[id]/edit/images.types.ts
@@ -1,0 +1,36 @@
+/** An upload in flight or finished, held in the browser until she commits the batch. */
+export interface PendingImage {
+    /** Stable client-side key. Not a Convex id — nothing is written yet. */
+    key: string;
+    fileName: string;
+    title: string;
+    stage: 'resizing' | 'uploading' | 'ready' | 'failed';
+    error?: string;
+    /** Populated once the upload lands. */
+    imagePath?: string;
+    width?: number;
+    height?: number;
+    thumbnailPath?: string;
+    thumbnailWidth?: number;
+    thumbnailHeight?: number;
+    /** Local object URL, so a thumbnail is visible while the bytes are still going up. */
+    previewUrl?: string;
+}
+
+/** One image already attached to the project. */
+export interface CommittedImage {
+    _id: string;
+    title?: string;
+    imagePath: string;
+    width: number;
+    height: number;
+    thumbnailPath?: string;
+    displayOrder: number;
+}
+
+export const UPLOAD_STAGE_LABELS: Record<PendingImage['stage'], string> = {
+    resizing: 'Resizing',
+    uploading: 'Uploading',
+    ready: 'Ready',
+    failed: 'Failed',
+};

--- a/src/app/admin/projects/[id]/edit/useImageUpload.ts
+++ b/src/app/admin/projects/[id]/edit/useImageUpload.ts
@@ -1,0 +1,163 @@
+'use client';
+
+import { useCallback, useRef, useState } from 'react';
+import { generateReactHelpers } from '@uploadthing/react';
+
+import type { OurFileRouter } from '@/app/api/uploadthing/core';
+import { reportUploadError } from '@/utils/uploads/uploadErrors';
+
+import type { PendingImage } from './images.types';
+
+const { useUploadThing } = generateReactHelpers<OurFileRouter>();
+
+/**
+ * Selecting files, resizing them, and getting them to storage — reported the whole way.
+ *
+ * The old uploader did all of this behind a single button label and then wrote every image straight
+ * onto the project, so a ten-image drop was silent until it was already irreversible. Here each file
+ * appears the moment it is chosen, carries its own stage, and lands in a pending list that is not
+ * written anywhere until she says so.
+ */
+
+const MAX_EDGE = 1920;
+const THUMBNAIL_EDGE = 450;
+
+function resize(file: File, maxEdge: number): Promise<File> {
+    return new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onerror = () => reject(new Error(`Could not read ${file.name}`));
+        reader.onload = (event) => {
+            const image = new window.Image();
+            image.onerror = () => reject(new Error(`${file.name} is not an image we can read`));
+            image.onload = () => {
+                if (image.width <= maxEdge && image.height <= maxEdge) return resolve(file);
+
+                const ratio = Math.min(maxEdge / image.width, maxEdge / image.height);
+                const canvas = document.createElement('canvas');
+                canvas.width = image.width * ratio;
+                canvas.height = image.height * ratio;
+                canvas.getContext('2d')?.drawImage(image, 0, 0, canvas.width, canvas.height);
+
+                canvas.toBlob((blob) => {
+                    if (blob) resolve(new File([blob], file.name, { type: file.type }));
+                    else reject(new Error(`Could not resize ${file.name}`));
+                }, file.type);
+            };
+            image.src = event.target?.result as string;
+        };
+        reader.readAsDataURL(file);
+    });
+}
+
+function measure(url: string): Promise<{ width: number; height: number }> {
+    return new Promise((resolve, reject) => {
+        const image = new window.Image();
+        image.onload = () => resolve({ width: image.naturalWidth, height: image.naturalHeight });
+        image.onerror = () => reject(new Error('Could not measure the uploaded image'));
+        image.src = url;
+    });
+}
+
+export function useImageUpload(onReady: (images: PendingImage[]) => void, onStageChange: (update: PendingImage) => void) {
+    const [progress, setProgress] = useState(0);
+    const [busy, setBusy] = useState(false);
+    /* Maps the upload response back to the cards already on screen, which are keyed client-side. */
+    const keysByFileName = useRef(new Map<string, string>());
+
+    const { startUpload } = useUploadThing('imageUploader', {
+        onUploadProgress: setProgress,
+        onUploadError: (error: Error) => {
+            reportUploadError(error, () => {});
+            for (const key of keysByFileName.current.values()) {
+                onStageChange({ key, stage: 'failed', error: 'Upload failed' } as PendingImage);
+            }
+            setBusy(false);
+            setProgress(0);
+        },
+        onClientUploadComplete: async (response) => {
+            try {
+                const files = (response ?? []) as { name: string; url: string }[];
+                const originals = files.filter((file) => !file.name.startsWith('small-'));
+
+                const ready: PendingImage[] = [];
+                for (const original of originals) {
+                    const key = keysByFileName.current.get(original.name);
+                    if (!key) continue;
+
+                    const small = files.find((file) => file.name === `small-${original.name}`);
+                    const [full, thumb] = await Promise.all([measure(original.url), small ? measure(small.url) : Promise.resolve(null)]);
+
+                    ready.push({
+                        key,
+                        fileName: original.name,
+                        title: '',
+                        stage: 'ready',
+                        imagePath: original.url,
+                        width: full.width,
+                        height: full.height,
+                        thumbnailPath: small?.url,
+                        thumbnailWidth: thumb?.width,
+                        thumbnailHeight: thumb?.height,
+                    });
+                }
+
+                onReady(ready);
+            } finally {
+                keysByFileName.current.clear();
+                setBusy(false);
+                setProgress(0);
+            }
+        },
+    });
+
+    const upload = useCallback(
+        async (fileList: FileList) => {
+            const files = Array.from(fileList);
+            if (files.length === 0) return;
+
+            setBusy(true);
+            setProgress(0);
+            keysByFileName.current.clear();
+
+            /* Every file gets a card immediately, so nothing about the batch is invisible. */
+            const staged = files.map((file, index) => {
+                const key = `${file.name}-${index}-${file.size}`;
+                keysByFileName.current.set(file.name, key);
+                return {
+                    key,
+                    fileName: file.name,
+                    title: '',
+                    stage: 'resizing' as const,
+                    previewUrl: URL.createObjectURL(file),
+                };
+            });
+            onReady(staged);
+
+            const toUpload: File[] = [];
+            for (const [index, file] of files.entries()) {
+                try {
+                    const [full, small] = await Promise.all([resize(file, MAX_EDGE), resize(file, THUMBNAIL_EDGE)]);
+                    toUpload.push(new File([small], `small-${file.name}`, { type: small.type }), full);
+                    onStageChange({ key: staged[index].key, stage: 'uploading' } as PendingImage);
+                } catch (error) {
+                    onStageChange({
+                        key: staged[index].key,
+                        stage: 'failed',
+                        error: error instanceof Error ? error.message : 'Could not prepare this file',
+                    } as PendingImage);
+                    keysByFileName.current.delete(file.name);
+                }
+            }
+
+            if (toUpload.length === 0) {
+                setBusy(false);
+                return;
+            }
+
+            await startUpload(toUpload);
+        },
+        [onReady, onStageChange, startUpload],
+    );
+
+    return { upload, progress, busy };
+}


### PR DESCRIPTION
Uploading photos to a project used to write every file straight to the database the moment it finished — no progress, no chance to arrange anything, and no way back except deleting rows one at a time. This branch gives the editor a pending state, gives every photo a caption, and replaces the three-tab layout with a single column.

## Photos are staged before they are written

Selecting or dropping files now produces cards immediately, each carrying its own stage, and nothing is written to the project until **Add photos** is pressed.

```mermaid
flowchart LR
    A[Choose or drop files] --> B[Card appears<br/>local preview]
    B --> C[Resizing]
    C --> D[Uploading]
    D --> E[Ready]
    E --> F{Arrange}
    F -->|caption, reorder, drop| F
    F --> G[Add photos<br/>one transaction]
    G --> H[On this project]
```

A failed file fails on its own card and the rest of the batch still commits. `addProjectImages` writes the whole batch in one mutation, in the order shown, so the arrangement made above is exactly what the site gets.

## The same edits apply after commit

| Edit | Pending list | On the project |
|---|---|---|
| Caption | local, committed with the batch | written on blur |
| Reorder | local | written immediately |
| Remove | discards the card | deletes the row |

One card component serves both lists; the only real difference is when an edit lands. Reordering is drag-and-drop **and** a pair of move buttons, because drag-only ordering cannot be operated from a keyboard and this is the control that decides which photo the portfolio shows first.

## Captions reach the public site

`projectImages` gains an optional `title`. Where the portfolio grid and lightbox previously read `"<project>, image 4"`, they now use the caption when one exists, for both `alt` and the trigger's `aria-label`.

## One column instead of three tabs

Details, Photos and Inventory are stacked sections under a sticky header that carries the project name, its status, a jump link per section with live counts, and a save button reachable from anywhere on the page.

Two behaviours changed with it:

- Saving stays on the page and reports `Saved`, instead of navigating to the project list. Saving from the middle of arranging photos no longer throws the page away.
- Form state seeds from the query during render, keyed on the project id, rather than in an effect keyed on the query result. The subscription re-emits after every photo edit, and the old effect re-seeded the form each time — typing into a field while an upload landed lost the edit.

The details form was rebuilt on the admin tokens; it was still using `bg-primary` and `text-white`. The status select explains what each value does, since `completed` and `cancelled` trigger the inventory check-in step.

## Homepage biography

The About section's copy is restored to its original wording. The updated styling stays; only the text reverts.
