### PR TITLE
Track project payments and rebuild the projects list

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -22,6 +22,7 @@ import type * as homepageImages from "../homepageImages.js";
 import type * as inventory from "../inventory.js";
 import type * as inventoryInsights from "../inventoryInsights.js";
 import type * as inventoryRules from "../inventoryRules.js";
+import type * as payments from "../payments.js";
 import type * as projects from "../projects.js";
 import type * as users from "../users.js";
 
@@ -43,6 +44,7 @@ declare const fullApi: ApiFromModules<{
   inventory: typeof inventory;
   inventoryInsights: typeof inventoryInsights;
   inventoryRules: typeof inventoryRules;
+  payments: typeof payments;
   projects: typeof projects;
   users: typeof users;
 }>;

--- a/convex/dashboard.ts
+++ b/convex/dashboard.ts
@@ -2,6 +2,7 @@ import { query } from "./_generated/server";
 import { isAdmin } from "./authz";
 import { availabilityByItem, isClosedStatus } from "./availability";
 import { attentionReasons, highestTier } from "./inventoryRules";
+import { isAwaitingPayment } from "./payments";
 
 /**
  * The figures behind the dashboard and the analytics page.
@@ -56,7 +57,7 @@ export const getDashboardSummary = query({
 
     const activeProjects = projects.filter((project) => project.status === "active");
     const completedProjects = projects.filter((project) => project.status === "completed");
-    const awaitingPayment = completedProjects.filter((project) => !project.paymentReceivedAt);
+    const awaitingPayment = completedProjects.filter(isAwaitingPayment);
 
     const startOfYear = new Date(new Date().getFullYear(), 0, 1).getTime();
     const revenueThisYear = completedProjects
@@ -163,7 +164,7 @@ export const getProjectsNeedingAttention = query({
           .collect();
 
         const awaitingCheckIn = isClosedStatus(project.status) && open.length > 0;
-        const awaitingPayment = project.status === "completed" && !project.paymentReceivedAt;
+        const awaitingPayment = isAwaitingPayment(project);
 
         return {
           _id: project._id,

--- a/convex/payments.ts
+++ b/convex/payments.ts
@@ -1,0 +1,48 @@
+import type { Doc } from "./_generated/dataModel";
+
+/**
+ * What a project has been paid.
+ *
+ * Payment used to be a single nullable timestamp, which could only answer "has any money arrived".
+ * A staging job is regularly settled in two parts — a deposit up front, the balance at closing — so
+ * the answer has to be a status plus an amount, and "some of it" has to be a state the dashboard can
+ * see. Rows predate all of it, so every read goes through here rather than touching the columns.
+ */
+
+export type PaymentStatus = "unpaid" | "partial" | "paid";
+
+export interface PaymentState {
+  status: PaymentStatus;
+  /** When the money arrived. Undefined while unpaid. */
+  paidOn?: number;
+  amountPaid: number;
+  invoiced: number;
+  /** Never negative: an overpayment is settled, not owed backwards. */
+  outstanding: number;
+  method?: string;
+  notes?: string;
+}
+
+export function paymentState(project: Doc<"projects">): PaymentState {
+  /* A legacy row with a receipt date but no status was fully paid — that was all the field could mean. */
+  const status: PaymentStatus = project.paymentStatus ?? (project.paymentReceivedAt ? "paid" : "unpaid");
+  const invoiced = project.revenue ?? 0;
+
+  /* Same reasoning for the amount: before this existed, paid meant paid in full. */
+  const amountPaid = project.amountPaid ?? (status === "paid" ? invoiced : 0);
+
+  return {
+    status,
+    paidOn: project.paymentReceivedAt,
+    amountPaid,
+    invoiced,
+    outstanding: Math.max(0, invoiced - amountPaid),
+    method: project.paymentMethod,
+    notes: project.paymentNotes,
+  };
+}
+
+/** A finished job whose money has not fully arrived. Drives the dashboard's follow-up list. */
+export function isAwaitingPayment(project: Doc<"projects">) {
+  return project.status === "completed" && paymentState(project).status !== "paid";
+}

--- a/convex/projects.ts
+++ b/convex/projects.ts
@@ -3,6 +3,7 @@ import { mutation, query } from "./_generated/server";
 import type { Id } from "./_generated/dataModel";
 import { isAdmin, requireAdmin } from "./authz";
 import { openAssignments, syncItemCounter, syncProjectFlag } from "./availability";
+import { paymentState } from "./payments";
 
 // Get highlighted projects for portfolio
 export const getHighlightedProjects = query({
@@ -68,19 +69,120 @@ export const getProjectOptions = query({
 
 export const getAllProjects = query({
   handler: async (ctx) => {
-    const identity = await ctx.auth.getUserIdentity();
-    if (!identity) return [];
-
-    const user = await ctx.db
-      .query("users")
-      .withIndex("by_clerk_id", (q) => q.eq("clerkId", identity.subject))
-      .first();
-
-    if (!user || user.role !== "admin") {
-      throw new Error("Not authorized");
-    }
+    if (!(await isAdmin(ctx))) return [];
 
     return await ctx.db.query("projects").withIndex("by_order").collect();
+  },
+});
+
+/**
+ * The projects list, with everything the list and its detail column need in one subscription.
+ *
+ * The list used to render raw project rows, so the only way to learn that a job still had furniture
+ * out or money outstanding was to open it. Those are the two facts worth chasing, so they belong on
+ * the row.
+ */
+export const getProjectsOverview = query({
+  handler: async (ctx) => {
+    if (!(await isAdmin(ctx))) return [];
+
+    const projects = await ctx.db.query("projects").withIndex("by_order").collect();
+
+    return await Promise.all(
+      projects.map(async (project) => {
+        const [open, images] = await Promise.all([
+          ctx.db
+            .query("projectInventory")
+            .withIndex("by_active", (q) => q.eq("projectId", project._id).eq("returnedAt", undefined))
+            .collect(),
+          ctx.db
+            .query("projectImages")
+            .withIndex("by_project", (q) => q.eq("projectId", project._id))
+            .collect(),
+        ]);
+
+        return {
+          _id: project._id,
+          name: project.name,
+          status: project.status,
+          address: project.address,
+          startDate: project.startDate,
+          endDate: project.endDate,
+          revenue: project.revenue,
+          notes: project.notes,
+          highlighted: project.highlighted,
+          displayOrder: project.displayOrder,
+          createdAt: project.createdAt,
+          imageCount: images.length,
+          openUnits: open.reduce((total, row) => total + row.quantity, 0),
+          openValue: open.reduce((total, row) => total + row.quantity * row.pricePerItem, 0),
+          payment: paymentState(project),
+        };
+      }),
+    );
+  },
+});
+
+/**
+ * Records money against a project.
+ *
+ * Marking a job paid is the moment to capture the rest of it, so this takes the date and the amount
+ * together rather than flipping a flag and leaving the amount to be reconstructed later. Passing an
+ * amount that covers the invoice settles the job outright even when "partial" was chosen, because
+ * the number is the fact and the radio button is a guess.
+ */
+export const recordProjectPayment = mutation({
+  args: {
+    projectId: v.id("projects"),
+    paidOn: v.number(),
+    amountPaid: v.number(),
+    /* What she selected. Reconciled against the invoice below. */
+    intent: v.union(v.literal("partial"), v.literal("paid")),
+    method: v.optional(v.string()),
+    notes: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    await requireAdmin(ctx);
+
+    const project = await ctx.db.get(args.projectId);
+    if (!project) throw new Error("Project not found");
+    if (args.amountPaid < 0) throw new Error("A payment cannot be negative");
+
+    const invoiced = project.revenue ?? 0;
+    const settled = invoiced > 0 ? args.amountPaid >= invoiced : args.intent === "paid";
+
+    await ctx.db.patch(args.projectId, {
+      paymentStatus: settled ? "paid" : "partial",
+      paymentReceivedAt: args.paidOn,
+      amountPaid: args.amountPaid,
+      paymentMethod: args.method?.trim() || undefined,
+      paymentNotes: args.notes?.trim() || undefined,
+      updatedAt: Date.now(),
+    });
+
+    return { status: settled ? "paid" : "partial", outstanding: Math.max(0, invoiced - args.amountPaid) };
+  },
+});
+
+/** Undoes a payment record — the way back from a wrong date or a mistaken toggle. */
+export const clearProjectPayment = mutation({
+  args: { projectId: v.id("projects") },
+  handler: async (ctx, args) => {
+    await requireAdmin(ctx);
+
+    const project = await ctx.db.get(args.projectId);
+    if (!project) throw new Error("Project not found");
+
+    await ctx.db.patch(args.projectId, {
+      paymentStatus: "unpaid",
+      paymentReceivedAt: undefined,
+      amountPaid: undefined,
+      paymentMethod: undefined,
+      paymentNotes: undefined,
+      updatedAt: Date.now(),
+    });
+
+    return { success: true };
   },
 });
 
@@ -360,34 +462,23 @@ export const deleteProjectImage = mutation({
 export const getProjectById = query({
   args: { projectId: v.id("projects") },
   handler: async (ctx, args) => {
-    const identity = await ctx.auth.getUserIdentity();
-    if (!identity) throw new Error("Not authenticated");
-
-    // Check if user is admin
-    const user = await ctx.db
-      .query("users")
-      .withIndex("by_clerk_id", (q) => q.eq("clerkId", identity.subject))
-      .first();
-
-    if (!user || user.role !== "admin") {
-      throw new Error("Not authorized");
-    }
+    await requireAdmin(ctx);
 
     const project = await ctx.db.get(args.projectId);
     if (!project) return null;
 
-    // Get project images ordered by displayOrder
     const images = await ctx.db
       .query("projectImages")
       .withIndex("by_project", (q) => q.eq("projectId", args.projectId))
       .collect();
 
-    // Sort images by displayOrder
     images.sort((a, b) => (a.displayOrder || 0) - (b.displayOrder || 0));
 
     return {
       ...project,
       images,
+      /* Derived rather than raw: the stored columns predate partial payments. */
+      payment: paymentState(project),
     };
   },
 });

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -65,8 +65,17 @@ export default defineSchema({
     endDate: v.optional(v.number()),
     revenue: v.optional(v.number()),
     address: v.optional(v.string()),
+    /*
+     * Payment. `paymentReceivedAt` predates the rest and holds the date the money arrived; the three
+     * fields below record how much, how, and what is still outstanding. Rows written before this
+     * existed carry no status, so read payment through `paymentState` rather than these directly.
+     */
     paymentReceivedAt: v.optional(v.number()),
     paymentProcessedAt: v.optional(v.number()),
+    paymentStatus: v.optional(v.union(v.literal("unpaid"), v.literal("partial"), v.literal("paid"))),
+    amountPaid: v.optional(v.number()),
+    paymentMethod: v.optional(v.string()),
+    paymentNotes: v.optional(v.string()),
     mlsLink: v.optional(v.string()),
     invoiceLink: v.optional(v.string()),
     highlighted: v.boolean(),

--- a/src/app/admin/inventory/CatalogSidePanel.tsx
+++ b/src/app/admin/inventory/CatalogSidePanel.tsx
@@ -1,7 +1,9 @@
 'use client';
 
-import { useEffect } from 'react';
-import { House, PackageSearch, X } from 'lucide-react';
+import { useCallback } from 'react';
+import { House, PackageSearch } from 'lucide-react';
+
+import AdminSidePanel from '@/components/admin/AdminSidePanel';
 
 import type { LineProblem, StagingSummary } from '@/components/admin/inventory/staging.types';
 
@@ -9,14 +11,7 @@ import ItemDetailPanel from './ItemDetailPanel';
 import ProjectWorkspacePanel from './ProjectWorkspacePanel';
 import type { CatalogItem, ProjectOption } from './catalog.types';
 
-/**
- * The catalog's third column.
- *
- * From `xl` up it sits in the layout, so the grid keeps scrolling behind whatever is open and there
- * is no scrim to dismiss. Below that width there is not enough room for three columns, so the same
- * panel becomes a slide-over — one component, two wrappers, rather than two implementations that
- * drift apart.
- */
+/** The catalog's third column: what it shows, over the shared responsive panel that positions it. */
 export default function CatalogSidePanel({
     open,
     onOpenChange,
@@ -47,17 +42,11 @@ export default function CatalogSidePanel({
     onClear: () => void;
     onCommit: () => void;
 }) {
-    /* Escape closes the overlay at narrow widths. At `xl` the panel is furniture, not a dialog. */
-    useEffect(() => {
-        if (!open) return;
-        const onKeyDown = (event: KeyboardEvent) => {
-            if (event.key !== 'Escape') return;
-            if (detailItemId) onCloseDetail();
-            else onOpenChange(false);
-        };
-        document.addEventListener('keydown', onKeyDown);
-        return () => document.removeEventListener('keydown', onKeyDown);
-    }, [open, detailItemId, onCloseDetail, onOpenChange]);
+    /* Escape steps back out of an item before it closes the panel itself. */
+    const handleEscape = useCallback(() => {
+        if (detailItemId) onCloseDetail();
+        else onOpenChange(false);
+    }, [detailItemId, onCloseDetail, onOpenChange]);
 
     const body = detailItemId ? (
         <ItemDetailPanel itemId={detailItemId} onClose={onCloseDetail} projects={projects} activeProjectId={project?._id ?? null} />
@@ -85,42 +74,13 @@ export default function CatalogSidePanel({
     );
 
     return (
-        <>
-            {/* Overlay wrapper, below xl only. */}
-            {open && (
-                <div className="fixed inset-0 z-50 flex justify-end xl:hidden">
-                    <button
-                        type="button"
-                        aria-label="Close panel"
-                        onClick={() => onOpenChange(false)}
-                        className="bg-ink/70 absolute inset-0"
-                    />
-                    <aside
-                        role="dialog"
-                        aria-modal="true"
-                        aria-label={detailItemId ? 'Item details' : 'Staging list'}
-                        className="border-line bg-surface-raised shadow-overlay relative flex h-full w-full max-w-md flex-col border-l"
-                    >
-                        <button
-                            type="button"
-                            onClick={() => onOpenChange(false)}
-                            aria-label="Close panel"
-                            className="border-line bg-surface-raised text-body-muted hover:text-body absolute top-3 -left-11 grid h-9 w-9 place-items-center rounded-md border transition-colors"
-                        >
-                            <X size={16} aria-hidden="true" />
-                        </button>
-                        {body}
-                    </aside>
-                </div>
-            )}
-
-            {/* In-flow column, xl and up. */}
-            <aside
-                aria-label={detailItemId ? 'Item details' : 'Staging list'}
-                className="border-line bg-surface-raised sticky top-0 hidden max-h-[calc(100dvh-64px)] w-[22rem] shrink-0 flex-col self-start border-l xl:flex 2xl:w-[24rem]"
-            >
-                {body}
-            </aside>
-        </>
+        <AdminSidePanel
+            open={open}
+            onOpenChange={onOpenChange}
+            label={detailItemId ? 'Item details' : 'Staging list'}
+            onEscape={handleEscape}
+        >
+            {body}
+        </AdminSidePanel>
     );
 }

--- a/src/app/admin/projects/AdminProjectsClient.tsx
+++ b/src/app/admin/projects/AdminProjectsClient.tsx
@@ -1,238 +1,264 @@
 'use client';
 
-import { useQuery, useMutation } from 'convex/react';
-import { api } from '@/convex/_generated/api';
+import { useMemo, useState } from 'react';
 import Link from 'next/link';
-import { Edit3, Plus, Trash2, ChevronUp, ChevronDown } from 'lucide-react';
-import { useState } from 'react';
-import { Tooltip } from 'react-tooltip';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { useMutation, useQuery } from 'convex/react';
+import { FolderOpen, Plus, Search, SlidersHorizontal, X } from 'lucide-react';
 
-import { SkeletonBlock, SkeletonTable } from '@/components/admin/AdminSkeleton';
+import { api } from '@/convex/_generated/api';
+import type { Id } from '@/convex/_generated/dataModel';
+import { AdminHeading } from '@/components/admin/AdminPrimitives';
+import AdminSidePanel from '@/components/admin/AdminSidePanel';
+import { SkeletonListRows } from '@/components/admin/AdminSkeleton';
+import ProjectPaymentDialog from '@/components/admin/projects/ProjectPaymentDialog';
+import { money } from '@/components/admin/projects/payments.constants';
 
-const PROJECT_COLUMNS = ['Order', 'Name', 'Status', 'Address', 'Started', 'Highlighted', 'Actions'] as const;
+import ProjectDetailPanel from './ProjectDetailPanel';
+import ProjectRow from './ProjectRow';
+import { MONEY_FILTERS, STATUS_FILTERS } from './projects.constants';
+import type { MoneyFilter, ProjectOverviewRow, StatusFilter } from './projects.types';
 
+/**
+ * Every project, beside the one that is selected.
+ *
+ * This was a wide table whose every row ended in three icons, which meant the only way to learn
+ * anything about a job was to leave the page. The list now carries the two facts that prompt action —
+ * furniture still out, money still owed — and the selected project opens in a column that stays put
+ * while the list keeps scrolling.
+ *
+ * Selection lives in the URL so a project can be linked to, and so returning from its editor lands
+ * back on the same row.
+ */
 export default function AdminProjectsClient() {
-    const projects = useQuery(api.projects.getAllProjects);
+    const router = useRouter();
+    const pathname = usePathname();
+    const searchParams = useSearchParams();
+
+    const projects = useQuery(api.projects.getProjectsOverview) as ProjectOverviewRow[] | undefined;
     const toggleHighlight = useMutation(api.projects.toggleProjectHighlight);
-    const deleteProject = useMutation(api.projects.deleteProject);
-    const moveProjectUp = useMutation(api.projects.moveProjectUp);
-    const moveProjectDown = useMutation(api.projects.moveProjectDown);
-    const moveProjectToFirst = useMutation(api.projects.moveProjectToFirst);
-    const moveProjectToLast = useMutation(api.projects.moveProjectToLast);
-    const [showDeleteConfirm, setShowDeleteConfirm] = useState<string | null>(null);
+    const moveUp = useMutation(api.projects.moveProjectUp);
+    const moveDown = useMutation(api.projects.moveProjectDown);
+    const moveToFirst = useMutation(api.projects.moveProjectToFirst);
+    const moveToLast = useMutation(api.projects.moveProjectToLast);
 
-    const handleToggleHighlight = async (projectId: string) => {
-        try {
-            await toggleHighlight({ projectId: projectId as any });
-        } catch (error) {
-            console.error('Error toggling highlight:', error);
-        }
+    const selectedId = searchParams.get('project');
+
+    const [search, setSearch] = useState('');
+    const [status, setStatus] = useState<StatusFilter>('all');
+    const [payment, setPayment] = useState<MoneyFilter>('all');
+    const [panelOpen, setPanelOpen] = useState(false);
+    const [payingId, setPayingId] = useState<string | null>(null);
+
+    const filtered = useMemo(() => {
+        const term = search.trim().toLowerCase();
+        return (projects ?? []).filter((project) => {
+            if (status !== 'all' && project.status !== status) return false;
+            if (payment === 'owed' && project.payment.status === 'paid') return false;
+            if (payment === 'paid' && project.payment.status !== 'paid') return false;
+            if (!term) return true;
+            return `${project.name} ${project.address ?? ''}`.toLowerCase().includes(term);
+        });
+    }, [projects, search, status, payment]);
+
+    const filtering = search.trim().length > 0 || status !== 'all' || payment !== 'all';
+    const selected = (projects ?? []).find((project) => project._id === selectedId) ?? null;
+    const paying = (projects ?? []).find((project) => project._id === payingId) ?? null;
+
+    const totals = useMemo(() => {
+        const rows = projects ?? [];
+        const outstanding = rows.reduce((total, project) => total + project.payment.outstanding, 0);
+        return {
+            count: rows.length,
+            active: rows.filter((project) => project.status === 'active').length,
+            owed: rows.filter((project) => project.status === 'completed' && project.payment.status !== 'paid').length,
+            outstanding,
+        };
+    }, [projects]);
+
+    const select = (projectId: string) => {
+        const params = new URLSearchParams(searchParams.toString());
+        if (projectId === selectedId) params.delete('project');
+        else params.set('project', projectId);
+        router.replace(params.size ? `${pathname}?${params}` : pathname, { scroll: false });
+        setPanelOpen(projectId !== selectedId);
     };
 
-    const handleDeleteProject = async (projectId: string) => {
-        try {
-            await deleteProject({ id: projectId as any });
-            setShowDeleteConfirm(null);
-        } catch (error) {
-            console.error('Error deleting project:', error);
-        }
+    const handleMove = (project: ProjectOverviewRow, direction: -1 | 1) => {
+        const all = projects ?? [];
+        const index = all.findIndex((row) => row._id === project._id);
+        const args = { projectId: project._id as Id<'projects'> };
+
+        /* The ends wrap, which is how a project gets to the front of the portfolio in one click. */
+        if (direction === -1) void (index === 0 ? moveToLast(args) : moveUp(args));
+        else void (index === all.length - 1 ? moveToFirst(args) : moveDown(args));
     };
 
-    const handleMoveUp = async (projectId: string, isFirst: boolean) => {
-        console.log('Moving up:', { projectId, isFirst });
-        try {
-            if (isFirst) {
-                console.log('Moving to last position');
-                await moveProjectToLast({ projectId: projectId as any });
-            } else {
-                console.log('Moving up normally');
-                await moveProjectUp({ projectId: projectId as any });
-            }
-            console.log('Move up completed');
-        } catch (error) {
-            console.error('Error moving project up:', error);
-        }
-    };
-
-    const handleMoveDown = async (projectId: string, isLast: boolean) => {
-        console.log('Moving down:', { projectId, isLast });
-        try {
-            if (isLast) {
-                console.log('Moving to first position');
-                await moveProjectToFirst({ projectId: projectId as any });
-            } else {
-                console.log('Moving down normally');
-                await moveProjectDown({ projectId: projectId as any });
-            }
-            console.log('Move down completed');
-        } catch (error) {
-            console.error('Error moving project down:', error);
-        }
-    };
-
-    if (projects === undefined) {
-        return (
-            <div className="container mx-auto p-4">
-                <div className="mb-6 flex items-center justify-between">
-                    <h1 className="text-body text-3xl font-bold">Manage Projects</h1>
-                    <SkeletonBlock className="h-10 w-40 rounded" />
-                </div>
-                <SkeletonTable headers={PROJECT_COLUMNS} rows={6} label="Loading projects" />
-            </div>
-        );
-    }
+    const panelBody = selected ? (
+        <ProjectDetailPanel
+            project={selected}
+            onOpenPayment={() => setPayingId(selected._id)}
+            onDeleted={() => {
+                router.replace(pathname, { scroll: false });
+                setPanelOpen(false);
+            }}
+        />
+    ) : (
+        <div className="flex flex-1 flex-col items-center justify-center gap-3 p-6 text-center">
+            <FolderOpen size={26} aria-hidden="true" className="text-body-subtle" />
+            <strong className="font-display text-body text-base leading-tight font-normal">No project selected</strong>
+            <p className="text-body-muted max-w-[16rem] text-sm">
+                Pick a project to see its money, its furniture and its photos, and to change the small things without opening it.
+            </p>
+        </div>
+    );
 
     return (
-        <div className="container mx-auto p-4">
-            <div className="mb-6 flex items-center justify-between">
-                <h1 className="text-body text-3xl font-bold">Manage Projects</h1>
-                <Link
-                    href="/admin/projects/new"
-                    className="bg-primary hover:bg-primary_dark rounded px-4 py-2 text-white transition-colors"
-                >
-                    Create New Project
-                </Link>
+        <div className="flex min-h-full flex-col xl:flex-row xl:items-start">
+            <div className="flex min-w-0 flex-1 flex-col gap-5 p-5 sm:p-8">
+                <AdminHeading
+                    eyebrow="Back office"
+                    title="Projects"
+                    description={
+                        totals.owed > 0
+                            ? `${totals.count} projects, ${totals.active} active. ${totals.owed} finished ${totals.owed === 1 ? 'job is' : 'jobs are'} still owed ${money.format(totals.outstanding)}.`
+                            : `${totals.count} projects, ${totals.active} active. Nothing is outstanding.`
+                    }
+                    action={
+                        <Link
+                            href="/admin/projects/new"
+                            className="bg-gold-400 text-body-inverse hover:bg-gold-300 inline-flex shrink-0 items-center gap-2 rounded-md px-4 py-2.5 text-sm font-bold transition-colors"
+                        >
+                            <Plus size={15} aria-hidden="true" /> New project
+                        </Link>
+                    }
+                />
+
+                <div className="flex flex-col gap-2.5">
+                    <label className="relative block">
+                        <span className="sr-only">Search projects</span>
+                        <Search
+                            size={15}
+                            aria-hidden="true"
+                            className="text-body-subtle pointer-events-none absolute top-1/2 left-3 -translate-y-1/2"
+                        />
+                        <input
+                            type="search"
+                            value={search}
+                            onChange={(event) => setSearch(event.target.value)}
+                            placeholder="Search by name or address"
+                            className="border-line bg-surface text-body placeholder:text-body-subtle focus-visible:border-gold-300 w-full rounded-md border py-2.5 pr-3 pl-9 text-sm transition-colors outline-none"
+                        />
+                    </label>
+
+                    <div className="flex flex-wrap items-center gap-1.5">
+                        {STATUS_FILTERS.map((option) => (
+                            <button
+                                key={option.value}
+                                type="button"
+                                onClick={() => setStatus(option.value)}
+                                aria-pressed={status === option.value}
+                                className={`rounded-full border px-3 py-1.5 text-xs font-bold transition-colors ${
+                                    status === option.value
+                                        ? 'border-gold-300/60 bg-gold-400/10 text-gold-200'
+                                        : 'border-line text-body-muted hover:bg-surface-hover hover:text-body'
+                                }`}
+                            >
+                                {option.label}
+                            </button>
+                        ))}
+
+                        <span aria-hidden="true" className="bg-line mx-1 h-5 w-px" />
+
+                        {MONEY_FILTERS.map((option) => (
+                            <button
+                                key={option.value}
+                                type="button"
+                                onClick={() => setPayment(option.value)}
+                                aria-pressed={payment === option.value}
+                                className={`rounded-full border px-3 py-1.5 text-xs font-bold transition-colors ${
+                                    payment === option.value
+                                        ? 'border-gold-300/60 bg-gold-400/10 text-gold-200'
+                                        : 'border-line text-body-muted hover:bg-surface-hover hover:text-body'
+                                }`}
+                            >
+                                {option.label}
+                            </button>
+                        ))}
+
+                        {filtering && (
+                            <button
+                                type="button"
+                                onClick={() => {
+                                    setSearch('');
+                                    setStatus('all');
+                                    setPayment('all');
+                                }}
+                                className="text-body-subtle hover:text-body ml-auto inline-flex items-center gap-1 text-xs font-bold transition-colors"
+                            >
+                                <X size={12} aria-hidden="true" /> Clear filters
+                            </button>
+                        )}
+                    </div>
+                </div>
+
+                <div className="border-line bg-surface-raised min-h-0 flex-1 overflow-hidden rounded-lg border">
+                    {projects === undefined ? (
+                        <SkeletonListRows rows={6} label="Loading projects" />
+                    ) : filtered.length === 0 ? (
+                        <div className="flex flex-col items-center gap-3 px-5 py-12 text-center">
+                            <FolderOpen size={24} aria-hidden="true" className="text-body-subtle" />
+                            <p className="text-body-muted text-sm">
+                                {projects.length === 0 ? 'No projects yet.' : 'No projects match those filters.'}
+                            </p>
+                            {projects.length === 0 && (
+                                <Link
+                                    href="/admin/projects/new"
+                                    className="bg-gold-400 text-body-inverse hover:bg-gold-300 inline-flex items-center gap-2 rounded-md px-4 py-2.5 text-sm font-bold transition-colors"
+                                >
+                                    <Plus size={15} aria-hidden="true" /> Create the first one
+                                </Link>
+                            )}
+                        </div>
+                    ) : (
+                        <>
+                            {filtering && (
+                                <p className="border-line text-body-subtle flex items-center gap-1.5 border-b px-4 py-2 text-xs">
+                                    <SlidersHorizontal size={11} aria-hidden="true" />
+                                    Showing {filtered.length} of {projects.length}. Portfolio order can only be changed with filters
+                                    cleared.
+                                </p>
+                            )}
+                            <ul className="divide-line divide-y">
+                                {filtered.map((project) => (
+                                    <ProjectRow
+                                        key={project._id}
+                                        project={project}
+                                        selected={project._id === selectedId}
+                                        reorderable={!filtering}
+                                        onSelect={() => select(project._id)}
+                                        onMove={(direction) => handleMove(project, direction)}
+                                        onToggleHighlight={() => void toggleHighlight({ projectId: project._id as Id<'projects'> })}
+                                    />
+                                ))}
+                            </ul>
+                        </>
+                    )}
+                </div>
             </div>
 
-            {projects.length === 0 ? (
-                <div className="py-12 text-center">
-                    <p className="text-body-subtle text-lg">No projects yet.</p>
-                    <Link
-                        href="/admin/projects/new"
-                        className="bg-primary hover:bg-primary_dark mt-4 inline-block rounded px-6 py-3 text-white transition-colors"
-                    >
-                        Create Your First Project
-                    </Link>
-                </div>
-            ) : (
-                <div className="overflow-x-auto">
-                    <table className="bg-surface-raised min-w-full rounded-lg">
-                        <thead>
-                            <tr className="">
-                                <th className="text-body px-4 py-3 text-center">Order</th>
-                                <th className="text-body px-4 py-3 text-left">Name</th>
-                                <th className="text-body px-4 py-3 text-left">Status</th>
-                                <th className="text-body px-4 py-3 text-left">Address</th>
-                                <th className="text-body px-4 py-3 text-left">Started</th>
-                                <th className="text-body px-4 py-3 text-center">Highlighted</th>
-                                <th className="text-body px-4 py-3 text-center">Actions</th>
-                            </tr>
-                        </thead>
-                        <tbody className="">
-                            {projects.map((project, index) => (
-                                <tr key={project._id} className="border-line text-body-muted border-t">
-                                    <td className="px-4 py-3 text-center">
-                                        <div className="flex items-center justify-center">
-                                            <button
-                                                onClick={() => handleMoveUp(project._id, index === 0)}
-                                                className="text-body-subtle hover:text-body hover:bg-surface-overlay rounded p-1 transition-colors"
-                                                data-tooltip-id="move-up-tooltip"
-                                                data-tooltip-content={index === 0 ? 'Move to Last' : 'Move Up'}
-                                            >
-                                                <ChevronUp size={16} />
-                                            </button>
-                                            <span className="w-8 text-center text-sm font-medium">{index + 1}</span>
-                                            <button
-                                                onClick={() => handleMoveDown(project._id, index === projects.length - 1)}
-                                                className="text-body-subtle hover:text-body hover:bg-surface-overlay rounded p-1 transition-colors"
-                                                data-tooltip-id="move-down-tooltip"
-                                                data-tooltip-content={index === projects.length - 1 ? 'Move to First' : 'Move Down'}
-                                            >
-                                                <ChevronDown size={16} />
-                                            </button>
-                                        </div>
-                                    </td>
-                                    <td className="px-4 py-3 font-medium">{project.name}</td>
-                                    <td className="px-4 py-3">
-                                        <span
-                                            className={`rounded px-2 py-1 text-xs font-medium ${
-                                                project.status === 'active'
-                                                    ? 'bg-secondary text-white'
-                                                    : project.status === 'completed'
-                                                      ? 'bg-blue-600 text-white'
-                                                      : project.status === 'draft'
-                                                        ? 'bg-gray-600 text-white'
-                                                        : 'bg-red-600 text-white'
-                                            }`}
-                                        >
-                                            {project.status}
-                                        </span>
-                                    </td>
-                                    <td className="px-4 py-3">{project.address || '-'}</td>
-                                    <td className="px-4 py-3">
-                                        {project.startDate ? new Date(project.startDate).toLocaleDateString() : '-'}
-                                    </td>
-                                    <td className="px-4 py-3 text-center">
-                                        <button
-                                            onClick={() => handleToggleHighlight(project._id)}
-                                            className={`rounded px-3 py-1 text-sm font-medium transition-colors ${
-                                                project.highlighted
-                                                    ? 'bg-primary hover:bg-primary_dark text-white'
-                                                    : 'bg-surface-hover text-body-muted hover:bg-stone-500'
-                                            }`}
-                                        >
-                                            {project.highlighted ? 'Yes' : 'No'}
-                                        </button>
-                                    </td>
-                                    <td className="relative px-4 py-3 text-center">
-                                        <div className="flex justify-center gap-2">
-                                            <Link
-                                                href={`/admin/projects/${project._id}/edit`}
-                                                className="hover:bg-surface-overlay rounded p-2 text-blue-400 transition-colors hover:text-blue-300"
-                                                data-tooltip-id="edit-tooltip"
-                                                data-tooltip-content="Edit Project"
-                                            >
-                                                <Edit3 size={18} />
-                                            </Link>
-                                            <Link
-                                                href={`/admin/projects/${project._id}/inventory`}
-                                                className="text-secondary_light hover:bg-surface-overlay hover:text-secondary rounded p-2 transition-colors"
-                                                data-tooltip-id="inventory-tooltip"
-                                                data-tooltip-content="Manage Inventory"
-                                            >
-                                                <Plus size={18} />
-                                            </Link>
-                                            <button
-                                                onClick={() => setShowDeleteConfirm(project._id)}
-                                                className="hover:bg-surface-overlay rounded p-2 text-red-400 transition-colors hover:text-red-300"
-                                                data-tooltip-id="delete-tooltip"
-                                                data-tooltip-content="Delete Project"
-                                            >
-                                                <Trash2 size={18} />
-                                            </button>
-                                        </div>
-                                        {showDeleteConfirm === project._id && (
-                                            <div className="border-line-strong bg-surface-overlay absolute top-full left-1/2 z-10 mt-2 min-w-64 -translate-x-1/2 transform rounded-lg border p-4 shadow-lg">
-                                                <p className="text-body mb-3 text-sm">Are you sure you want to delete this project?</p>
-                                                <div className="flex justify-center gap-2">
-                                                    <button
-                                                        onClick={() => setShowDeleteConfirm(null)}
-                                                        className="bg-surface-hover text-body-muted rounded px-3 py-1 text-sm transition-colors hover:bg-stone-500"
-                                                    >
-                                                        Cancel
-                                                    </button>
-                                                    <button
-                                                        onClick={() => handleDeleteProject(project._id)}
-                                                        className="rounded bg-red-600 px-3 py-1 text-sm text-white transition-colors hover:bg-red-700"
-                                                    >
-                                                        Confirm
-                                                    </button>
-                                                </div>
-                                            </div>
-                                        )}
-                                    </td>
-                                </tr>
-                            ))}
-                        </tbody>
-                    </table>
-                </div>
-            )}
+            <AdminSidePanel open={panelOpen && selected !== null} onOpenChange={setPanelOpen} label="Project details">
+                {panelBody}
+            </AdminSidePanel>
 
-            <Tooltip id="edit-tooltip" place="top" />
-            <Tooltip id="inventory-tooltip" place="top" />
-            <Tooltip id="delete-tooltip" place="top" />
-            <Tooltip id="move-up-tooltip" place="top" />
-            <Tooltip id="move-down-tooltip" place="top" />
+            {paying && (
+                <ProjectPaymentDialog
+                    projectId={paying._id}
+                    projectName={paying.name}
+                    payment={paying.payment}
+                    onClose={() => setPayingId(null)}
+                />
+            )}
         </div>
     );
 }

--- a/src/app/admin/projects/ProjectDetailPanel.tsx
+++ b/src/app/admin/projects/ProjectDetailPanel.tsx
@@ -1,0 +1,341 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { useMutation } from 'convex/react';
+import { AlertTriangle, BadgeDollarSign, CheckCircle2, Images, Loader2, PackageOpen, Pencil, Trash2, Undo2 } from 'lucide-react';
+
+import { api } from '@/convex/_generated/api';
+import type { Id } from '@/convex/_generated/dataModel';
+import PaymentBadge from '@/components/admin/projects/PaymentBadge';
+import { exactMoney, money, shortDate } from '@/components/admin/projects/payments.constants';
+
+import { STATUS_LABELS, STATUS_TONES } from './projects.constants';
+import type { ProjectOverviewRow, ProjectStatus } from './projects.types';
+
+/**
+ * The selected project, in the column beside the list.
+ *
+ * Everything here is either a fact worth seeing before deciding to open the project, or an edit
+ * small enough that opening it would be the slower path. Anything larger — photos, the furniture
+ * manifest — is a link, not a second implementation of the editor.
+ */
+
+const FIELD =
+    'border-line bg-surface text-body placeholder:text-body-subtle focus-visible:border-gold-300 w-full rounded-md border px-3 py-2 text-sm outline-none transition-colors';
+const LABEL = 'text-body-muted text-xs font-bold';
+
+const STATUS_ORDER: ProjectStatus[] = ['draft', 'active', 'completed', 'cancelled'];
+
+export default function ProjectDetailPanel({
+    project,
+    onOpenPayment,
+    onDeleted,
+}: {
+    project: ProjectOverviewRow;
+    onOpenPayment: () => void;
+    onDeleted: () => void;
+}) {
+    const updateProject = useMutation(api.projects.updateProject);
+    const clearPayment = useMutation(api.projects.clearProjectPayment);
+    const deleteProject = useMutation(api.projects.deleteProject);
+
+    const [draft, setDraft] = useState<{ name: string; status: ProjectStatus; revenue: string } | null>(null);
+    const [saving, setSaving] = useState(false);
+    const [saved, setSaved] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const [confirmingDelete, setConfirmingDelete] = useState(false);
+
+    const payment = project.payment;
+    const closing = project.status === 'completed' || project.status === 'cancelled';
+
+    const startEditing = () =>
+        setDraft({ name: project.name, status: project.status, revenue: project.revenue ? String(project.revenue) : '' });
+
+    const handleSave = async () => {
+        if (!draft) return;
+        setSaving(true);
+        setError(null);
+        try {
+            await updateProject({
+                projectId: project._id as Id<'projects'>,
+                name: draft.name,
+                status: draft.status,
+                revenue: draft.revenue ? parseFloat(draft.revenue) : undefined,
+                /* Required by the mutation and toggled elsewhere on this page; passed through unchanged. */
+                highlighted: project.highlighted,
+            });
+            setDraft(null);
+            setSaved(true);
+        } catch (caught) {
+            setError(caught instanceof Error ? caught.message : 'Could not save those changes.');
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    const handleDelete = async () => {
+        setSaving(true);
+        setError(null);
+        try {
+            await deleteProject({ id: project._id as Id<'projects'> });
+            onDeleted();
+        } catch (caught) {
+            setError(caught instanceof Error ? caught.message : 'Could not delete this project.');
+            setSaving(false);
+        }
+    };
+
+    return (
+        <div className="flex min-h-0 flex-1 flex-col">
+            <header className="border-line flex flex-col gap-2 border-b px-4 py-4">
+                <span className="text-body-subtle text-[10px] font-extrabold tracking-[0.14em] uppercase">Project</span>
+                <h2 className="font-display text-body text-lg leading-tight font-normal">{project.name}</h2>
+                <div className="flex flex-wrap items-center gap-1.5">
+                    <span className={`rounded-full border px-2.5 py-1 text-[11px] font-bold ${STATUS_TONES[project.status]}`}>
+                        {STATUS_LABELS[project.status]}
+                    </span>
+                    <PaymentBadge payment={payment} showBalance />
+                </div>
+                {project.address && <p className="text-body-subtle text-xs">{project.address}</p>}
+            </header>
+
+            <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-4">
+                <dl className="grid grid-cols-2 gap-2">
+                    {[
+                        { label: 'Revenue', value: project.revenue ? money.format(project.revenue) : '—' },
+                        { label: 'Started', value: project.startDate ? shortDate.format(new Date(project.startDate)) : '—' },
+                        { label: 'Ended', value: project.endDate ? shortDate.format(new Date(project.endDate)) : '—' },
+                        { label: 'On site', value: project.openUnits > 0 ? `${project.openUnits} units` : 'Nothing' },
+                    ].map((fact) => (
+                        <div key={fact.label} className="border-line bg-surface flex flex-col gap-0.5 rounded-md border px-3 py-2">
+                            <dt className="text-body-subtle text-[10px] font-extrabold tracking-[0.14em] uppercase">{fact.label}</dt>
+                            <dd className="text-body text-sm font-bold">{fact.value}</dd>
+                        </div>
+                    ))}
+                </dl>
+
+                {closing && project.openUnits > 0 && (
+                    <p className="border-warning/40 bg-warning-soft text-warning flex items-start gap-2 rounded-md border px-3.5 py-2.5 text-xs">
+                        <AlertTriangle size={13} aria-hidden="true" className="mt-0.5 shrink-0" />
+                        <span>
+                            This job is {STATUS_LABELS[project.status].toLowerCase()} but {project.openUnits} units are still recorded as
+                            being at the house.{' '}
+                            <Link href={`/admin/projects/${project._id}/edit#inventory`} className="font-bold underline">
+                                Check them in
+                            </Link>{' '}
+                            so the catalog shows them as available.
+                        </span>
+                    </p>
+                )}
+
+                <section className="border-line bg-surface flex flex-col gap-2.5 rounded-md border p-3.5">
+                    <div className="flex items-center justify-between gap-2">
+                        <h3 className="text-body inline-flex items-center gap-1.5 text-sm font-bold">
+                            <BadgeDollarSign size={14} aria-hidden="true" className="text-body-subtle" /> Payment
+                        </h3>
+                        <PaymentBadge payment={payment} />
+                    </div>
+
+                    {payment.status === 'unpaid' ? (
+                        <p className="text-body-muted text-xs">
+                            {project.revenue
+                                ? `${money.format(project.revenue)} invoiced, nothing recorded as received.`
+                                : 'No revenue is set on this project yet.'}
+                        </p>
+                    ) : (
+                        <dl className="flex flex-col gap-1 text-xs">
+                            <div className="flex justify-between gap-3">
+                                <dt className="text-body-subtle">Received</dt>
+                                <dd className="text-body font-bold">{exactMoney.format(payment.amountPaid)}</dd>
+                            </div>
+                            {payment.outstanding > 0 && (
+                                <div className="flex justify-between gap-3">
+                                    <dt className="text-body-subtle">Outstanding</dt>
+                                    <dd className="text-warning font-bold">{exactMoney.format(payment.outstanding)}</dd>
+                                </div>
+                            )}
+                            {payment.paidOn && (
+                                <div className="flex justify-between gap-3">
+                                    <dt className="text-body-subtle">Dated</dt>
+                                    <dd className="text-body-muted">{shortDate.format(new Date(payment.paidOn))}</dd>
+                                </div>
+                            )}
+                            {payment.method && (
+                                <div className="flex justify-between gap-3">
+                                    <dt className="text-body-subtle">Method</dt>
+                                    <dd className="text-body-muted">{payment.method}</dd>
+                                </div>
+                            )}
+                            {payment.notes && <p className="text-body-subtle border-line mt-1 border-t pt-2">{payment.notes}</p>}
+                        </dl>
+                    )}
+
+                    <div className="flex flex-wrap gap-2">
+                        <button
+                            type="button"
+                            onClick={onOpenPayment}
+                            className="bg-gold-400 text-body-inverse hover:bg-gold-300 rounded-md px-3.5 py-2 text-xs font-bold transition-colors"
+                        >
+                            {payment.status === 'unpaid'
+                                ? 'Mark as paid'
+                                : payment.status === 'partial'
+                                  ? 'Record another payment'
+                                  : 'Edit payment'}
+                        </button>
+                        {payment.status !== 'unpaid' && (
+                            <button
+                                type="button"
+                                onClick={() => void clearPayment({ projectId: project._id as Id<'projects'> })}
+                                className="border-line text-body-muted hover:bg-surface-hover hover:text-body inline-flex items-center gap-1.5 rounded-md border px-3 py-2 text-xs font-bold transition-colors"
+                            >
+                                <Undo2 size={12} aria-hidden="true" /> Clear
+                            </button>
+                        )}
+                    </div>
+                </section>
+
+                <section className="flex flex-col gap-2.5">
+                    <div className="flex items-center justify-between gap-2">
+                        <h3 className="text-body text-sm font-bold">Quick edit</h3>
+                        {!draft && (
+                            <button
+                                type="button"
+                                onClick={startEditing}
+                                className="text-gold-300 hover:text-gold-200 inline-flex items-center gap-1.5 text-xs font-bold transition-colors"
+                            >
+                                <Pencil size={12} aria-hidden="true" /> Edit here
+                            </button>
+                        )}
+                    </div>
+
+                    {draft ? (
+                        <div className="flex flex-col gap-3">
+                            <label className="flex flex-col gap-1.5">
+                                <span className={LABEL}>Name</span>
+                                <input
+                                    type="text"
+                                    value={draft.name}
+                                    onChange={(event) => setDraft({ ...draft, name: event.target.value })}
+                                    className={FIELD}
+                                />
+                            </label>
+                            <label className="flex flex-col gap-1.5">
+                                <span className={LABEL}>Status</span>
+                                <select
+                                    value={draft.status}
+                                    onChange={(event) => setDraft({ ...draft, status: event.target.value as ProjectStatus })}
+                                    className={FIELD}
+                                >
+                                    {STATUS_ORDER.map((status) => (
+                                        <option key={status} value={status}>
+                                            {STATUS_LABELS[status]}
+                                        </option>
+                                    ))}
+                                </select>
+                            </label>
+                            <label className="flex flex-col gap-1.5">
+                                <span className={LABEL}>Revenue</span>
+                                <input
+                                    type="number"
+                                    step="0.01"
+                                    value={draft.revenue}
+                                    onChange={(event) => setDraft({ ...draft, revenue: event.target.value })}
+                                    placeholder="0.00"
+                                    className={FIELD}
+                                />
+                            </label>
+                            <div className="flex gap-2">
+                                <button
+                                    type="button"
+                                    onClick={handleSave}
+                                    disabled={saving}
+                                    className="bg-gold-400 text-body-inverse hover:bg-gold-300 inline-flex items-center gap-2 rounded-md px-3.5 py-2 text-xs font-bold transition-colors disabled:opacity-50"
+                                >
+                                    {saving && <Loader2 size={12} aria-hidden="true" className="animate-spin" />} Save
+                                </button>
+                                <button
+                                    type="button"
+                                    onClick={() => setDraft(null)}
+                                    className="border-line text-body-muted hover:bg-surface-hover hover:text-body rounded-md border px-3 py-2 text-xs font-bold transition-colors"
+                                >
+                                    Cancel
+                                </button>
+                            </div>
+                        </div>
+                    ) : (
+                        <p aria-live="polite" className="text-body-subtle text-xs">
+                            {saved ? (
+                                <span className="text-success inline-flex items-center gap-1.5 font-bold">
+                                    <CheckCircle2 size={12} aria-hidden="true" /> Saved
+                                </span>
+                            ) : (
+                                'Name, status and revenue can be changed without leaving the list.'
+                            )}
+                        </p>
+                    )}
+                </section>
+
+                {error && (
+                    <p role="alert" className="border-danger/40 bg-danger-soft text-danger rounded-md border px-3.5 py-2.5 text-xs">
+                        {error}
+                    </p>
+                )}
+            </div>
+
+            <footer className="border-line flex flex-col gap-2 border-t p-4">
+                <div className="grid grid-cols-2 gap-2">
+                    <Link
+                        href={`/admin/projects/${project._id}/edit`}
+                        className="border-line-strong text-body hover:bg-surface-hover inline-flex items-center justify-center gap-1.5 rounded-md border px-3 py-2.5 text-xs font-bold transition-colors"
+                    >
+                        <Pencil size={13} aria-hidden="true" /> Open project
+                    </Link>
+                    <Link
+                        href={`/admin/projects/${project._id}/inventory`}
+                        className="border-line-strong text-body hover:bg-surface-hover inline-flex items-center justify-center gap-1.5 rounded-md border px-3 py-2.5 text-xs font-bold transition-colors"
+                    >
+                        <PackageOpen size={13} aria-hidden="true" /> Furniture
+                    </Link>
+                </div>
+                <Link
+                    href={`/admin/projects/${project._id}/edit#photos`}
+                    className="border-line text-body-muted hover:bg-surface-hover hover:text-body inline-flex items-center justify-center gap-1.5 rounded-md border px-3 py-2 text-xs font-bold transition-colors"
+                >
+                    <Images size={13} aria-hidden="true" /> {project.imageCount} photos
+                </Link>
+
+                {confirmingDelete ? (
+                    <div className="border-danger/40 bg-danger-soft flex flex-col gap-2 rounded-md border p-3">
+                        <p className="text-danger text-xs font-bold">Delete {project.name}? Its photos and inventory history go with it.</p>
+                        <div className="flex gap-2">
+                            <button
+                                type="button"
+                                onClick={handleDelete}
+                                disabled={saving}
+                                className="bg-danger text-body-inverse inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-bold disabled:opacity-50"
+                            >
+                                {saving && <Loader2 size={12} aria-hidden="true" className="animate-spin" />} Delete
+                            </button>
+                            <button
+                                type="button"
+                                onClick={() => setConfirmingDelete(false)}
+                                className="border-line text-body-muted hover:text-body rounded-md border px-3 py-1.5 text-xs font-bold"
+                            >
+                                Keep
+                            </button>
+                        </div>
+                    </div>
+                ) : (
+                    <button
+                        type="button"
+                        onClick={() => setConfirmingDelete(true)}
+                        className="text-body-subtle hover:text-danger inline-flex items-center justify-center gap-1.5 py-1 text-xs font-bold transition-colors"
+                    >
+                        <Trash2 size={12} aria-hidden="true" /> Delete project
+                    </button>
+                )}
+            </footer>
+        </div>
+    );
+}

--- a/src/app/admin/projects/ProjectRow.tsx
+++ b/src/app/admin/projects/ProjectRow.tsx
@@ -1,0 +1,118 @@
+'use client';
+
+import { ChevronDown, ChevronUp, Images, MapPin, PackageOpen, Star } from 'lucide-react';
+
+import PaymentBadge from '@/components/admin/projects/PaymentBadge';
+import { money, shortDate } from '@/components/admin/projects/payments.constants';
+
+import { STATUS_LABELS, STATUS_TONES } from './projects.constants';
+import type { ProjectOverviewRow } from './projects.types';
+
+/**
+ * One project in the list.
+ *
+ * The row answers the two questions worth chasing without opening anything — is furniture still out,
+ * and is money still owed. Everything else lives in the detail column, so this stays scannable at a
+ * dozen rows.
+ *
+ * The reorder and highlight controls are siblings of the row button rather than children, because a
+ * button inside a button is invalid and the browser resolves it by dropping one of them.
+ */
+export default function ProjectRow({
+    project,
+    selected,
+    reorderable,
+    onSelect,
+    onMove,
+    onToggleHighlight,
+}: {
+    project: ProjectOverviewRow;
+    selected: boolean;
+    /** Order is global, so the arrows are hidden while a filter is hiding some of it. */
+    reorderable: boolean;
+    onSelect: () => void;
+    onMove: (direction: -1 | 1) => void;
+    onToggleHighlight: () => void;
+}) {
+    const owed = project.payment.status !== 'paid' && project.status === 'completed';
+
+    return (
+        <li
+            className={`relative border-l-2 transition-colors ${
+                selected ? 'border-l-gold-300 bg-surface-hover' : 'hover:bg-surface-hover/60 border-l-transparent'
+            }`}
+        >
+            <button
+                type="button"
+                onClick={onSelect}
+                aria-current={selected ? 'true' : undefined}
+                className="flex w-full flex-col gap-1.5 px-4 py-3 pr-24 text-left"
+            >
+                <span className="flex flex-wrap items-center gap-2">
+                    <strong className="text-body min-w-0 truncate text-sm font-bold">{project.name}</strong>
+                    <span className={`shrink-0 rounded-full border px-2 py-0.5 text-[11px] font-bold ${STATUS_TONES[project.status]}`}>
+                        {STATUS_LABELS[project.status]}
+                    </span>
+                    {(owed || project.payment.status !== 'unpaid') && <PaymentBadge payment={project.payment} showBalance />}
+                </span>
+
+                {project.address && (
+                    <span className="text-body-subtle inline-flex min-w-0 items-center gap-1 truncate text-xs">
+                        <MapPin size={11} aria-hidden="true" className="shrink-0" /> {project.address}
+                    </span>
+                )}
+
+                <span className="text-body-subtle flex flex-wrap items-center gap-x-3 gap-y-1 text-xs">
+                    {project.startDate && <span>{shortDate.format(new Date(project.startDate))}</span>}
+                    {project.revenue ? <span className="text-body-muted font-bold">{money.format(project.revenue)}</span> : null}
+                    {project.openUnits > 0 && (
+                        <span className="text-warning inline-flex items-center gap-1 font-bold">
+                            <PackageOpen size={11} aria-hidden="true" /> {project.openUnits} out
+                        </span>
+                    )}
+                    <span className="inline-flex items-center gap-1">
+                        <Images size={11} aria-hidden="true" /> {project.imageCount}
+                    </span>
+                </span>
+            </button>
+
+            <div className="absolute top-2.5 right-3 flex items-center gap-1">
+                <button
+                    type="button"
+                    onClick={onToggleHighlight}
+                    aria-pressed={project.highlighted}
+                    aria-label={project.highlighted ? `Remove ${project.name} from the portfolio` : `Show ${project.name} in the portfolio`}
+                    title={project.highlighted ? 'In the portfolio' : 'Not in the portfolio'}
+                    className={`grid h-7 w-7 place-items-center rounded border transition-colors ${
+                        project.highlighted
+                            ? 'border-gold-300/50 bg-gold-400/10 text-gold-300'
+                            : 'border-line text-body-subtle hover:bg-surface-hover hover:text-body'
+                    }`}
+                >
+                    <Star size={13} aria-hidden="true" fill={project.highlighted ? 'currentColor' : 'none'} />
+                </button>
+
+                {reorderable && (
+                    <div className="flex flex-col">
+                        <button
+                            type="button"
+                            onClick={() => onMove(-1)}
+                            aria-label={`Move ${project.name} earlier`}
+                            className="text-body-subtle hover:text-body grid h-4 w-6 place-items-center transition-colors"
+                        >
+                            <ChevronUp size={13} aria-hidden="true" />
+                        </button>
+                        <button
+                            type="button"
+                            onClick={() => onMove(1)}
+                            aria-label={`Move ${project.name} later`}
+                            className="text-body-subtle hover:text-body grid h-4 w-6 place-items-center transition-colors"
+                        >
+                            <ChevronDown size={13} aria-hidden="true" />
+                        </button>
+                    </div>
+                )}
+            </div>
+        </li>
+    );
+}

--- a/src/app/admin/projects/[id]/edit/EditProjectClient.tsx
+++ b/src/app/admin/projects/[id]/edit/EditProjectClient.tsx
@@ -4,13 +4,14 @@ import { useState } from 'react';
 import { useMutation, useQuery } from 'convex/react';
 import { useUser } from '@clerk/nextjs';
 import Link from 'next/link';
-import { ArrowLeft, Images, ListChecks, MapPin, SlidersHorizontal } from 'lucide-react';
+import { ArrowLeft, BadgeDollarSign, Images, ListChecks, MapPin, SlidersHorizontal } from 'lucide-react';
 
 import { api } from '@/convex/_generated/api';
 import type { Id } from '@/convex/_generated/dataModel';
 import CheckInDialog from './CheckInDialog';
 import ProjectDetailsForm from './ProjectDetailsForm';
 import ProjectImagesSection from './ProjectImagesSection';
+import ProjectPaymentSection from './ProjectPaymentSection';
 import ProjectInventoryTab from './ProjectInventoryTab';
 import type { CommittedImage } from './images.types';
 import { CLOSING_STATUSES, type ProjectAssignmentLine, type ProjectFormState, type ProjectStatus } from './project.types';
@@ -28,6 +29,7 @@ const DETAILS_FORM_ID = 'project-details-form';
 
 const SECTIONS = [
     { id: 'details', label: 'Details', icon: SlidersHorizontal },
+    { id: 'payment', label: 'Payment', icon: BadgeDollarSign },
     { id: 'photos', label: 'Photos', icon: Images },
     { id: 'inventory', label: 'Inventory', icon: ListChecks },
 ] as const;
@@ -170,6 +172,7 @@ export default function EditProjectClient({ projectId }: { projectId: string }) 
     const openCount = assignments?.open.length ?? 0;
     const counts: Record<(typeof SECTIONS)[number]['id'], number | null> = {
         details: null,
+        payment: null,
         photos: images.length,
         inventory: openCount,
     };
@@ -240,6 +243,10 @@ export default function EditProjectClient({ projectId }: { projectId: string }) 
                     error={saveError}
                     saved={saved}
                 />
+            </section>
+
+            <section id="payment" className="scroll-mt-32">
+                <ProjectPaymentSection projectId={projectId} projectName={project.name} payment={project.payment} />
             </section>
 
             <section id="photos" className="scroll-mt-32">

--- a/src/app/admin/projects/[id]/edit/ProjectPaymentSection.tsx
+++ b/src/app/admin/projects/[id]/edit/ProjectPaymentSection.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import { useState } from 'react';
+import { useMutation } from 'convex/react';
+import { Undo2 } from 'lucide-react';
+
+import { api } from '@/convex/_generated/api';
+import type { Id } from '@/convex/_generated/dataModel';
+import { AdminPanel } from '@/components/admin/AdminPrimitives';
+import PaymentBadge from '@/components/admin/projects/PaymentBadge';
+import ProjectPaymentDialog from '@/components/admin/projects/ProjectPaymentDialog';
+import { exactMoney, money, shortDate } from '@/components/admin/projects/payments.constants';
+import type { PaymentState } from '@/components/admin/projects/payments.types';
+
+/**
+ * What this job has been paid, on the project itself.
+ *
+ * Same dialog the list uses. Recording money is a step in its own right rather than four more fields
+ * on the details form: it has its own date, its own reconciliation against the invoice, and it is the
+ * one edit that gets made months after everything else on the page has stopped changing.
+ */
+export default function ProjectPaymentSection({
+    projectId,
+    projectName,
+    payment,
+}: {
+    projectId: string;
+    projectName: string;
+    payment: PaymentState;
+}) {
+    const clearPayment = useMutation(api.projects.clearProjectPayment);
+    const [dialogOpen, setDialogOpen] = useState(false);
+
+    return (
+        <>
+            <AdminPanel eyebrow="Money" title="Payment">
+                <div className="flex flex-col gap-4 p-4">
+                    <div className="flex flex-wrap items-center gap-3">
+                        <PaymentBadge payment={payment} />
+                        <span className="text-body-muted text-sm">
+                            {payment.status === 'unpaid'
+                                ? payment.invoiced > 0
+                                    ? `${money.format(payment.invoiced)} invoiced, nothing received yet.`
+                                    : 'No revenue is set on this project yet.'
+                                : `${exactMoney.format(payment.amountPaid)} received${
+                                      payment.paidOn ? ` on ${shortDate.format(new Date(payment.paidOn))}` : ''
+                                  }${payment.method ? ` by ${payment.method.toLowerCase()}` : ''}.`}
+                        </span>
+                    </div>
+
+                    {payment.outstanding > 0 && payment.status !== 'unpaid' && (
+                        <p className="border-warning/40 bg-warning-soft text-warning rounded-md border px-3.5 py-2.5 text-sm">
+                            {exactMoney.format(payment.outstanding)} is still outstanding on this job.
+                        </p>
+                    )}
+
+                    {payment.notes && <p className="text-body-subtle border-line border-t pt-3 text-sm">{payment.notes}</p>}
+
+                    <div className="border-line flex flex-wrap items-center gap-2 border-t pt-4">
+                        <button
+                            type="button"
+                            onClick={() => setDialogOpen(true)}
+                            className="bg-gold-400 text-body-inverse hover:bg-gold-300 rounded-md px-4 py-2.5 text-sm font-bold transition-colors"
+                        >
+                            {payment.status === 'unpaid'
+                                ? 'Mark as paid'
+                                : payment.status === 'partial'
+                                  ? 'Record another payment'
+                                  : 'Edit payment'}
+                        </button>
+                        {payment.status !== 'unpaid' && (
+                            <button
+                                type="button"
+                                onClick={() => void clearPayment({ projectId: projectId as Id<'projects'> })}
+                                className="border-line text-body-muted hover:bg-surface-hover hover:text-body inline-flex items-center gap-1.5 rounded-md border px-3.5 py-2.5 text-xs font-bold transition-colors"
+                            >
+                                <Undo2 size={13} aria-hidden="true" /> Clear payment
+                            </button>
+                        )}
+                    </div>
+                </div>
+            </AdminPanel>
+
+            {dialogOpen && (
+                <ProjectPaymentDialog
+                    projectId={projectId}
+                    projectName={projectName}
+                    payment={payment}
+                    onClose={() => setDialogOpen(false)}
+                />
+            )}
+        </>
+    );
+}

--- a/src/app/admin/projects/projects.constants.ts
+++ b/src/app/admin/projects/projects.constants.ts
@@ -1,0 +1,29 @@
+import type { MoneyFilter, ProjectStatus, StatusFilter } from './projects.types';
+
+export const STATUS_LABELS: Record<ProjectStatus, string> = {
+    draft: 'Draft',
+    active: 'Active',
+    completed: 'Completed',
+    cancelled: 'Cancelled',
+};
+
+export const STATUS_TONES: Record<ProjectStatus, string> = {
+    draft: 'border-line text-body-muted',
+    active: 'border-success/40 bg-success-soft text-success',
+    completed: 'border-info/40 bg-info-soft text-info',
+    cancelled: 'border-danger/40 bg-danger-soft text-danger',
+};
+
+export const STATUS_FILTERS: { value: StatusFilter; label: string }[] = [
+    { value: 'all', label: 'All' },
+    { value: 'active', label: 'Active' },
+    { value: 'completed', label: 'Completed' },
+    { value: 'draft', label: 'Draft' },
+    { value: 'cancelled', label: 'Cancelled' },
+];
+
+export const MONEY_FILTERS: { value: MoneyFilter; label: string }[] = [
+    { value: 'all', label: 'Any' },
+    { value: 'owed', label: 'Money owed' },
+    { value: 'paid', label: 'Settled' },
+];

--- a/src/app/admin/projects/projects.types.ts
+++ b/src/app/admin/projects/projects.types.ts
@@ -1,0 +1,25 @@
+import type { PaymentState } from '@/components/admin/projects/payments.types';
+
+export type ProjectStatus = 'draft' | 'active' | 'completed' | 'cancelled';
+
+/** One row of `projects.getProjectsOverview`. */
+export interface ProjectOverviewRow {
+    _id: string;
+    name: string;
+    status: ProjectStatus;
+    address?: string;
+    startDate?: number;
+    endDate?: number;
+    revenue?: number;
+    notes?: string;
+    highlighted: boolean;
+    displayOrder?: number;
+    createdAt: number;
+    imageCount: number;
+    openUnits: number;
+    openValue: number;
+    payment: PaymentState;
+}
+
+export type StatusFilter = 'all' | ProjectStatus;
+export type MoneyFilter = 'all' | 'owed' | 'paid';

--- a/src/components/admin/AdminSidePanel.tsx
+++ b/src/components/admin/AdminSidePanel.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import { useEffect } from 'react';
+import { X } from 'lucide-react';
+
+/**
+ * A detail column that is furniture on a wide screen and a slide-over on a narrow one.
+ *
+ * From `xl` up it sits in the layout, so the list keeps scrolling behind whatever is open and there
+ * is no scrim to dismiss. Below that width there is not enough room, so the same children become an
+ * overlay — one body, two wrappers, rather than two implementations that drift apart.
+ */
+export default function AdminSidePanel({
+    open,
+    onOpenChange,
+    label,
+    onEscape,
+    children,
+}: {
+    /** Only meaningful below `xl`, where the panel is an overlay. */
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    label: string;
+    /** Defaults to closing the overlay. Override when Escape should step back through a stack first. */
+    onEscape?: () => void;
+    children: React.ReactNode;
+}) {
+    useEffect(() => {
+        if (!open) return;
+        const onKeyDown = (event: KeyboardEvent) => {
+            if (event.key !== 'Escape') return;
+            if (onEscape) onEscape();
+            else onOpenChange(false);
+        };
+        document.addEventListener('keydown', onKeyDown);
+        return () => document.removeEventListener('keydown', onKeyDown);
+    }, [open, onEscape, onOpenChange]);
+
+    return (
+        <>
+            {open && (
+                <div className="fixed inset-0 z-50 flex justify-end xl:hidden">
+                    <button
+                        type="button"
+                        aria-label="Close panel"
+                        onClick={() => onOpenChange(false)}
+                        className="bg-ink/70 absolute inset-0"
+                    />
+                    <aside
+                        role="dialog"
+                        aria-modal="true"
+                        aria-label={label}
+                        className="border-line bg-surface-raised shadow-overlay relative flex h-full w-full max-w-md flex-col border-l"
+                    >
+                        <button
+                            type="button"
+                            onClick={() => onOpenChange(false)}
+                            aria-label="Close panel"
+                            className="border-line bg-surface-raised text-body-muted hover:text-body absolute top-3 -left-11 grid h-9 w-9 place-items-center rounded-md border transition-colors"
+                        >
+                            <X size={16} aria-hidden="true" />
+                        </button>
+                        {children}
+                    </aside>
+                </div>
+            )}
+
+            <aside
+                aria-label={label}
+                className="border-line bg-surface-raised sticky top-0 hidden max-h-[calc(100dvh-64px)] w-[22rem] shrink-0 flex-col self-start border-l xl:flex 2xl:w-[24rem]"
+            >
+                {children}
+            </aside>
+        </>
+    );
+}

--- a/src/components/admin/projects/PaymentBadge.tsx
+++ b/src/components/admin/projects/PaymentBadge.tsx
@@ -1,0 +1,16 @@
+import { PAYMENT_LABELS, PAYMENT_TONES, money } from './payments.constants';
+import type { PaymentState } from './payments.types';
+
+/** Payment status, carrying the outstanding balance when there is one. */
+export default function PaymentBadge({ payment, showBalance = false }: { payment: PaymentState; showBalance?: boolean }) {
+    const balance = showBalance && payment.status === 'partial' && payment.outstanding > 0;
+
+    return (
+        <span
+            className={`inline-flex shrink-0 items-center gap-1.5 rounded-full border px-2.5 py-1 text-[11px] font-bold ${PAYMENT_TONES[payment.status]}`}
+        >
+            {PAYMENT_LABELS[payment.status]}
+            {balance && <span className="font-normal opacity-80">{money.format(payment.outstanding)} left</span>}
+        </span>
+    );
+}

--- a/src/components/admin/projects/ProjectPaymentDialog.tsx
+++ b/src/components/admin/projects/ProjectPaymentDialog.tsx
@@ -1,0 +1,296 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { useMutation } from 'convex/react';
+import { AlertCircle, Loader2, X } from 'lucide-react';
+
+import { api } from '@/convex/_generated/api';
+import type { Id } from '@/convex/_generated/dataModel';
+
+import { PAYMENT_METHODS, exactMoney, fromDateInput, toDateInput } from './payments.constants';
+import type { PaymentState } from './payments.types';
+
+/**
+ * What she is asked when a job gets marked paid.
+ *
+ * A checkbox would record that money arrived and lose everything worth knowing about it — when, how
+ * much, and whether the balance is still outstanding. Staging jobs are routinely settled in two
+ * parts, so "partial" has to be a first-class answer rather than a note someone remembers to write.
+ *
+ * The amount is authoritative: entering the full invoice while "Partial" is selected settles the
+ * job, because the number is a fact and the radio button is an intention.
+ */
+
+const FIELD =
+    'border-line bg-surface text-body placeholder:text-body-subtle focus-visible:border-gold-300 w-full rounded-md border px-3 py-2.5 text-sm outline-none transition-colors';
+const LABEL = 'text-body-muted text-xs font-bold';
+
+export default function ProjectPaymentDialog({
+    projectId,
+    projectName,
+    payment,
+    onClose,
+}: {
+    projectId: string;
+    projectName: string;
+    payment: PaymentState;
+    onClose: () => void;
+}) {
+    const recordPayment = useMutation(api.projects.recordProjectPayment);
+
+    const invoiced = payment.invoiced;
+    const alreadyPaid = payment.amountPaid;
+
+    const [paidOn, setPaidOn] = useState(() => toDateInput(payment.paidOn));
+    const [intent, setIntent] = useState<'partial' | 'paid'>(payment.status === 'partial' ? 'partial' : 'paid');
+    /* Defaults to what is still owed, which is the amount being recorded far more often than not. */
+    const [amount, setAmount] = useState(() => {
+        const suggested = payment.status === 'partial' ? payment.outstanding : invoiced;
+        return suggested > 0 ? String(suggested) : '';
+    });
+    const [method, setMethod] = useState(payment.method ?? '');
+    const [notes, setNotes] = useState(payment.notes ?? '');
+    const [saving, setSaving] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    const closeRef = useRef<HTMLButtonElement>(null);
+
+    useEffect(() => {
+        closeRef.current?.focus();
+        const onKeyDown = (event: KeyboardEvent) => {
+            if (event.key === 'Escape') onClose();
+        };
+        document.addEventListener('keydown', onKeyDown);
+        return () => document.removeEventListener('keydown', onKeyDown);
+    }, [onClose]);
+
+    /*
+     * A partial payment adds to what has already been recorded; the field asks for this payment, not
+     * the running total, because that is what the cheque in her hand says.
+     */
+    const entered = Number(amount || 0);
+    const isTopUp = payment.status === 'partial';
+    const total = isTopUp ? alreadyPaid + entered : entered;
+    const settles = invoiced > 0 ? total >= invoiced : intent === 'paid';
+    const remaining = Math.max(0, invoiced - total);
+
+    const handleSubmit = async (event: React.FormEvent) => {
+        event.preventDefault();
+
+        if (!amount.trim() || Number.isNaN(entered)) return setError('Enter the amount received.');
+        if (entered < 0) return setError('A payment cannot be negative.');
+
+        setSaving(true);
+        setError(null);
+        try {
+            await recordPayment({
+                projectId: projectId as Id<'projects'>,
+                paidOn: fromDateInput(paidOn),
+                amountPaid: total,
+                intent,
+                method: method || undefined,
+                notes: notes || undefined,
+            });
+            onClose();
+        } catch (caught) {
+            setError(caught instanceof Error ? caught.message : 'Could not record that payment.');
+            setSaving(false);
+        }
+    };
+
+    return (
+        <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+            <button type="button" aria-label="Cancel" onClick={onClose} className="bg-ink/70 absolute inset-0" />
+
+            <div
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby="payment-dialog-title"
+                className="border-line bg-surface-raised shadow-overlay relative flex max-h-[90dvh] w-full max-w-md flex-col overflow-y-auto rounded-lg border"
+            >
+                <header className="border-line flex items-start justify-between gap-3 border-b px-5 py-4">
+                    <div className="flex min-w-0 flex-col gap-0.5">
+                        <span className="text-body-subtle text-[10px] font-extrabold tracking-[0.14em] uppercase">Payment</span>
+                        <h2 id="payment-dialog-title" className="font-display text-body truncate text-lg leading-tight font-normal">
+                            {projectName}
+                        </h2>
+                    </div>
+                    <button
+                        ref={closeRef}
+                        type="button"
+                        onClick={onClose}
+                        aria-label="Cancel"
+                        className="border-line text-body-muted hover:bg-surface-hover hover:text-body grid h-8 w-8 shrink-0 place-items-center rounded-md border transition-colors"
+                    >
+                        <X size={15} aria-hidden="true" />
+                    </button>
+                </header>
+
+                <form onSubmit={handleSubmit} className="flex flex-col gap-4 p-5">
+                    <dl className="border-line bg-surface flex items-center justify-between gap-3 rounded-md border px-3.5 py-2.5">
+                        <div className="flex flex-col gap-0.5">
+                            <dt className="text-body-subtle text-[10px] font-extrabold tracking-[0.14em] uppercase">Invoiced</dt>
+                            <dd className="text-body text-sm font-bold">{invoiced > 0 ? exactMoney.format(invoiced) : 'No revenue set'}</dd>
+                        </div>
+                        {isTopUp && (
+                            <div className="flex flex-col gap-0.5 text-right">
+                                <dt className="text-body-subtle text-[10px] font-extrabold tracking-[0.14em] uppercase">
+                                    Already recorded
+                                </dt>
+                                <dd className="text-body-muted text-sm font-bold">{exactMoney.format(alreadyPaid)}</dd>
+                            </div>
+                        )}
+                    </dl>
+
+                    <fieldset className="flex flex-col gap-2">
+                        <legend className={LABEL}>How much of it arrived?</legend>
+                        <div className="grid grid-cols-2 gap-2">
+                            {(
+                                [
+                                    { value: 'paid', label: 'In full', hint: 'Nothing outstanding' },
+                                    { value: 'partial', label: 'Part of it', hint: 'Balance still owed' },
+                                ] as const
+                            ).map((option) => (
+                                <label
+                                    key={option.value}
+                                    className={`flex cursor-pointer flex-col gap-0.5 rounded-md border px-3.5 py-2.5 transition-colors ${
+                                        intent === option.value ? 'border-gold-300/60 bg-gold-400/5' : 'border-line hover:bg-surface-hover'
+                                    }`}
+                                >
+                                    <span className="flex items-center gap-2">
+                                        <input
+                                            type="radio"
+                                            name="payment-intent"
+                                            value={option.value}
+                                            checked={intent === option.value}
+                                            onChange={() => {
+                                                setIntent(option.value);
+                                                if (option.value === 'paid' && invoiced > 0) {
+                                                    setAmount(String(isTopUp ? Math.max(0, invoiced - alreadyPaid) : invoiced));
+                                                }
+                                            }}
+                                            className="accent-gold-400 h-3.5 w-3.5"
+                                        />
+                                        <span className="text-body text-sm font-bold">{option.label}</span>
+                                    </span>
+                                    <span className="text-body-subtle pl-[1.375rem] text-xs">{option.hint}</span>
+                                </label>
+                            ))}
+                        </div>
+                    </fieldset>
+
+                    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                        <label className="flex flex-col gap-1.5">
+                            <span className={LABEL}>{isTopUp ? 'This payment' : 'Amount received'} *</span>
+                            <div className="relative">
+                                <span className="text-body-subtle pointer-events-none absolute top-1/2 left-3 -translate-y-1/2 text-sm">
+                                    $
+                                </span>
+                                <input
+                                    type="number"
+                                    step="0.01"
+                                    min="0"
+                                    required
+                                    value={amount}
+                                    onChange={(event) => setAmount(event.target.value)}
+                                    placeholder="0.00"
+                                    className={`${FIELD} pl-7`}
+                                />
+                            </div>
+                        </label>
+
+                        <label className="flex flex-col gap-1.5">
+                            <span className={LABEL}>Date received *</span>
+                            <input
+                                type="date"
+                                required
+                                value={paidOn}
+                                onChange={(event) => setPaidOn(event.target.value)}
+                                className={FIELD}
+                            />
+                        </label>
+                    </div>
+
+                    <div className="flex flex-col gap-1.5">
+                        <span className={LABEL}>How was it paid?</span>
+                        <div className="flex flex-wrap gap-1.5">
+                            {PAYMENT_METHODS.map((option) => (
+                                <button
+                                    key={option}
+                                    type="button"
+                                    onClick={() => setMethod(method === option ? '' : option)}
+                                    aria-pressed={method === option}
+                                    className={`rounded-full border px-3 py-1.5 text-xs font-bold transition-colors ${
+                                        method === option
+                                            ? 'border-gold-300/60 bg-gold-400/10 text-gold-200'
+                                            : 'border-line text-body-muted hover:bg-surface-hover hover:text-body'
+                                    }`}
+                                >
+                                    {option}
+                                </button>
+                            ))}
+                        </div>
+                        <input
+                            type="text"
+                            value={method}
+                            onChange={(event) => setMethod(event.target.value)}
+                            placeholder="Or type something else"
+                            className={FIELD}
+                        />
+                    </div>
+
+                    <label className="flex flex-col gap-1.5">
+                        <span className={LABEL}>Notes</span>
+                        <textarea
+                            value={notes}
+                            onChange={(event) => setNotes(event.target.value)}
+                            rows={2}
+                            placeholder="Check number, who paid, anything to remember."
+                            className={`${FIELD} resize-y`}
+                        />
+                    </label>
+
+                    <p
+                        aria-live="polite"
+                        className={`rounded-md border px-3.5 py-2.5 text-sm ${
+                            settles ? 'border-success/40 bg-success-soft text-success' : 'border-warning/40 bg-warning-soft text-warning'
+                        }`}
+                    >
+                        {invoiced === 0
+                            ? 'No revenue is set on this project, so nothing can be reconciled against it.'
+                            : settles
+                              ? `Recording ${exactMoney.format(total)} settles this job in full.`
+                              : `${exactMoney.format(remaining)} will still be outstanding.`}
+                    </p>
+
+                    {error && (
+                        <p
+                            role="alert"
+                            className="border-danger/40 bg-danger-soft text-danger flex items-start gap-2 rounded-md border px-3.5 py-2.5 text-sm"
+                        >
+                            <AlertCircle size={14} aria-hidden="true" className="mt-0.5 shrink-0" /> {error}
+                        </p>
+                    )}
+
+                    <div className="border-line flex items-center justify-end gap-2 border-t pt-4">
+                        <button
+                            type="button"
+                            onClick={onClose}
+                            className="border-line text-body-muted hover:bg-surface-hover hover:text-body rounded-md border px-4 py-2.5 text-sm font-bold transition-colors"
+                        >
+                            Cancel
+                        </button>
+                        <button
+                            type="submit"
+                            disabled={saving}
+                            className="bg-gold-400 text-body-inverse hover:bg-gold-300 inline-flex items-center gap-2 rounded-md px-4 py-2.5 text-sm font-bold transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+                        >
+                            {saving && <Loader2 size={15} aria-hidden="true" className="animate-spin" />}
+                            Record payment
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    );
+}

--- a/src/components/admin/projects/payments.constants.ts
+++ b/src/components/admin/projects/payments.constants.ts
@@ -1,0 +1,36 @@
+import type { PaymentStatus } from './payments.types';
+
+export const PAYMENT_LABELS: Record<PaymentStatus, string> = {
+    unpaid: 'Unpaid',
+    partial: 'Part paid',
+    paid: 'Paid',
+};
+
+export const PAYMENT_TONES: Record<PaymentStatus, string> = {
+    unpaid: 'border-line text-body-subtle',
+    partial: 'border-warning/40 bg-warning-soft text-warning',
+    paid: 'border-success/40 bg-success-soft text-success',
+};
+
+/*
+ * The ways a staging client actually pays. Free text is still allowed — this list only exists so the
+ * common cases are one tap instead of a spelling decision that makes the records inconsistent.
+ */
+export const PAYMENT_METHODS = ['Check', 'Bank transfer', 'Card', 'Cash', 'Venmo', 'Zelle'] as const;
+
+export const money = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 });
+export const exactMoney = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' });
+export const shortDate = new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+
+/** `<input type="date">` wants a local calendar day, not a UTC slice of a timestamp. */
+export function toDateInput(timestamp?: number) {
+    const date = timestamp ? new Date(timestamp) : new Date();
+    const offset = date.getTimezoneOffset() * 60_000;
+    return new Date(date.getTime() - offset).toISOString().slice(0, 10);
+}
+
+/** Noon local, so a payment dated today cannot land on the previous day in another timezone. */
+export function fromDateInput(value: string) {
+    const [year, month, day] = value.split('-').map(Number);
+    return new Date(year, month - 1, day, 12).getTime();
+}

--- a/src/components/admin/projects/payments.types.ts
+++ b/src/components/admin/projects/payments.types.ts
@@ -1,0 +1,12 @@
+export type PaymentStatus = 'unpaid' | 'partial' | 'paid';
+
+/** Payment as every admin surface reads it, derived server-side by `paymentState`. */
+export interface PaymentState {
+    status: PaymentStatus;
+    paidOn?: number;
+    amountPaid: number;
+    invoiced: number;
+    outstanding: number;
+    method?: string;
+    notes?: string;
+}


### PR DESCRIPTION
Two things a staging business needs from this page that it could not do: see which finished jobs still owe money, and record a payment that arrived in two parts. This branch adds payment tracking and rebuilds the projects list around a persistent detail column.

## Payment is a record, not a flag

`projects` previously had one nullable `paymentReceivedAt`, which could answer "has any money arrived" and nothing else. It now carries a status, an amount, a method and a note alongside that date.

Toggling a project to paid opens a dialog rather than flipping a switch:

| Question | Why it's asked |
|---|---|
| In full, or part of it? | Deposit-then-balance is the normal shape of a staging invoice |
| Amount received | Reconciled against `revenue` to decide the real status |
| Date received | The day the money arrived, not the day the record was made |
| Method | Six one-tap options, free text otherwise, so records stay consistent |
| Notes | Check number, who paid |

On a project that is already part paid, the field asks for *this* payment and shows what has already been recorded, because that is what the cheque in hand says. The dialog states the consequence live — `$1,200.00 will still be outstanding` or `Recording $3,400.00 settles this job in full` — before anything is written.

**The amount is authoritative.** Entering the full invoice while `Part of it` is selected settles the job, because the number is a fact and the radio button is an intention. `recordProjectPayment` does that reconciliation server-side, so it holds regardless of which surface called it.

Legacy rows have no status. Every read goes through `paymentState`, which treats a pre-existing receipt date as paid in full — that was all the field could mean. Nothing needs backfilling.

The dashboard's awaiting-payment figure moves to `isAwaitingPayment`, so a partially-paid job now correctly reads as still outstanding instead of settled.

## The list gained a detail column

```
┌──────────────────────────────┬──────────────────┐
│ search + status/money filters│  selected        │
│ ────────────────────────────│  project         │
│ ▸ 123 Oak St  Active  Paid   │  facts, payment, │
│ ▸ 44 Elm      Done  $900 left│  quick edit,     │
│ ▸ 8 Pine      Draft          │  links, delete   │
└──────────────────────────────┴──────────────────┘
```

Above `xl` the column sits in the layout, so the list keeps scrolling behind it and there is no scrim to dismiss. Below `xl` the same body becomes a slide-over. That wrapper is now `AdminSidePanel`, shared with the inventory catalog rather than a second copy of it.

Rows carry what prompts action — status, payment with the outstanding balance, how many units are still at the house, photo count — so the two questions worth chasing are answerable without opening anything. The three trailing icon links are gone; those actions live in the detail column.

From the column: mark or clear payment, change name, status and revenue in place, or open the full project, its furniture, or its photos. A finished job with furniture still recorded on site says so and links to the check-in.

Selection is in the URL (`?project=…`), so a project can be linked to and returning from its editor lands on the same row.

Filters cover search, status and `Money owed` / `Settled`. Reorder arrows hide while a filter is active and the list says why — display order is global, so moving a row inside a filtered view moves it past projects that aren't on screen.

## On the project itself

Payment is a section of the project editor too, using the same dialog, and joins the jump nav. It is a step of its own rather than four more fields on the details form: it has its own date, its own reconciliation, and it is the one edit made months after everything else on the page has stopped changing.

## Incidental

`getAllProjects` and `getProjectById` move onto the `authz` helpers, replacing hand-rolled identity lookups. `getProjectsOverview` returns the list and its counts in one subscription. The old list's `as any` casts and leftover `console.log` reordering traces are gone.
