### PR TITLE
Only advertise the services the business actually sells

### DIFF
--- a/src/app/_main_components/home.constants.ts
+++ b/src/app/_main_components/home.constants.ts
@@ -4,6 +4,9 @@ export const HERO_PROOF = [
     { value: 'RESA', label: 'certified stager' },
 ] as const;
 
+/** The two figures above are quoted, so the hero says where they came from and links the detail. */
+export const HERO_PROOF_SOURCE = 'Real Estate Staging Association and National Association of Realtors surveys.';
+
 export const HERO_FALLBACK_IMAGES = [
     { src: '/portfolio/stock/staging-stock-3.jpg', width: 2560, height: 1695 },
     { src: '/portfolio/stock/staging-stock-7.jpg', width: 564, height: 705 },

--- a/src/app/_main_components/home.tsx
+++ b/src/app/_main_components/home.tsx
@@ -9,7 +9,7 @@ import { api } from '@/convex/_generated/api';
 
 import { PRIMARY_ACTION, SECONDARY_ACTION } from '@/components/content/content.constants';
 import { track } from '@/lib/analytics';
-import { HERO_FALLBACK_IMAGES, HERO_PROOF, HERO_ROTATE_MS } from './home.constants';
+import { HERO_FALLBACK_IMAGES, HERO_PROOF, HERO_PROOF_SOURCE, HERO_ROTATE_MS } from './home.constants';
 
 type HomepageImage = { src: string; width: number; height: number };
 
@@ -114,6 +114,12 @@ export default function Home({ initialHomepageImages }: { initialHomepageImages?
                             </div>
                         ))}
                     </dl>
+                    <p className="text-body-subtle mt-3 text-[11px]">
+                        {HERO_PROOF_SOURCE}{' '}
+                        <Link href="/info/home-staging-statistics" className="hover:text-gold-300 underline transition-colors">
+                            See the figures
+                        </Link>
+                    </p>
                 </div>
             </div>
         </section>

--- a/src/app/admin/projects/[id]/edit/EditProjectClient.tsx
+++ b/src/app/admin/projects/[id]/edit/EditProjectClient.tsx
@@ -149,7 +149,7 @@ export default function EditProjectClient({ projectId }: { projectId: string }) 
     if (!user) {
         return (
             <p className="text-body-muted p-6 text-sm">
-                <Link href="/sign-in" className="text-gold-300 hover:text-gold-200 font-bold">
+                <Link href="/signin" className="text-gold-300 hover:text-gold-200 font-bold">
                     Sign in
                 </Link>{' '}
                 to edit this project.

--- a/src/app/info/cost-vs-value-analysis/page.tsx
+++ b/src/app/info/cost-vs-value-analysis/page.tsx
@@ -36,15 +36,12 @@ export default function CostVsValueAnalysis() {
                     />
                 }
             >
-                <p>
-                    One of the most common questions homeowners ask is whether the cost of home staging is worth the investment. This page
-                    covers how staging can provide a return by increasing your home&rsquo;s value and reducing time on the market.
-                </p>
-
                 <h2>The financial impact of home staging</h2>
                 <p>
-                    Staging is an investment rather than an expense. Staged homes often sell for 6 to 20% more than non-staged homes and
-                    spend 73% less time on the market. Those two factors together comfortably offset the initial cost.
+                    Staging is an investment rather than an expense. National surveys put staged homes at 6 to 20% above non-staged
+                    comparables and 73% less time on the market, and those two factors together generally offset the initial cost. Both
+                    figures are survey averages, so treat them as a reason to run the numbers on your own listing rather than a promise
+                    about it.
                 </p>
 
                 <h2>Breakdown of staging costs</h2>

--- a/src/app/info/home-staging-statistics/page.tsx
+++ b/src/app/info/home-staging-statistics/page.tsx
@@ -10,15 +10,32 @@ import { articleMetadata } from '@/app/info/article.metadata';
 
 const article = getArticle('home-staging-statistics');
 
+/**
+ * Figures carry the report they came from, not just the organisation. A seller weighing several
+ * thousand dollars of staging against a price reduction is entitled to know which study is being
+ * quoted and how broadly it applies.
+ */
 const HEADLINE_STATS = [
-    { value: '73%', label: 'less time on the market for professionally staged homes', source: 'Real Estate Staging Association' },
-    { value: '6-20%', label: 'increase in the dollar value buyers offer', source: 'National Association of Realtors' },
+    {
+        value: '73%',
+        label: 'less time on the market for professionally staged homes',
+        source: 'Real Estate Staging Association, consumer survey',
+    },
+    {
+        value: '6-20%',
+        label: 'increase in the dollar value buyers offer',
+        source: 'National Association of Realtors, Profile of Home Staging',
+    },
     {
         value: '81%',
         label: 'of buyers find it easier to visualize a staged property as their home',
-        source: 'National Association of Realtors',
+        source: 'National Association of Realtors, Profile of Home Staging',
     },
-    { value: '586%', label: 'peak return on investment reported for staging', source: 'HomeGain Selling Survey' },
+    {
+        value: '586%',
+        label: 'peak return on investment, reported as a high in one survey rather than a typical result',
+        source: 'HomeGain selling survey, historical',
+    },
 ];
 
 export const metadata: Metadata = articleMetadata(
@@ -40,18 +57,8 @@ export default function HomeStagingStatistics() {
                     width: article.imageWidth,
                     height: article.imageHeight,
                 }}
-                aside={
-                    <ContactCallout
-                        heading="Ready to benefit from staging?"
-                        body="Let us show you what these numbers look like for your specific property."
-                    />
-                }
+                aside={<ContactCallout heading="Price your property" body="See a staging range before you commit to a walkthrough." />}
             >
-                <p>
-                    Understanding the impact of home staging on the real estate market helps you make informed decisions when selling. Here
-                    are the figures that matter most.
-                </p>
-
                 <div className="not-prose my-10 grid grid-cols-1 gap-4 sm:grid-cols-2">
                     {HEADLINE_STATS.map((stat) => (
                         <div key={stat.value} className="border-line bg-surface-raised shadow-raised rounded-xl border p-5">
@@ -61,6 +68,11 @@ export default function HomeStagingStatistics() {
                         </div>
                     ))}
                 </div>
+
+                <p className="text-body-subtle text-sm">
+                    These are national survey figures. Results vary by market, price band and property, and none of them is a forecast for a
+                    specific listing.
+                </p>
 
                 <h2>Online appeal</h2>
                 <p>

--- a/src/app/locations/LocationPageTemplate.tsx
+++ b/src/app/locations/LocationPageTemplate.tsx
@@ -7,6 +7,8 @@ import JsonLd from '@/components/seo/JsonLd';
 import { serviceSchema, SITE_URL } from '@/lib/structuredData';
 import { SERVICE_AREAS } from '@/components/layout/Footer.constants';
 
+import { LOCATION_SERVICES } from './locations.constants';
+
 interface LocationPageProps {
     locationName: string;
     pageSlug: string;
@@ -14,7 +16,6 @@ interface LocationPageProps {
     imageAlt: string;
     description: string;
     whyStaging: string;
-    services: string[];
     contactText: string;
 }
 
@@ -25,7 +26,6 @@ export default function LocationPageTemplate({
     imageAlt,
     description,
     whyStaging,
-    services,
     contactText,
 }: LocationPageProps) {
     return (
@@ -40,12 +40,12 @@ export default function LocationPageTemplate({
             />
             <ArticleShell
                 eyebrow="Service area"
-                title={`Professional Home Staging in ${locationName}, CA`}
+                title={`Home staging in ${locationName}, CA`}
                 lead={description}
                 image={{ src: imageUrl, alt: imageAlt, width: 1280, height: 720 }}
                 aside={
                     <div className="space-y-12">
-                        <ContactCallout heading={`Staging in ${locationName}`} body={contactText} />
+                        <ContactCallout heading={`Staging in ${locationName}`} body={contactText} action="Get a free quote" />
                         <nav aria-label="Other service areas" className="border-line border-t pt-8">
                             <h2 className="font-display text-gold-300 text-xl font-semibold">Our service areas</h2>
                             <ul className="mt-5 grid grid-cols-2 gap-x-6 gap-y-3 sm:grid-cols-3 lg:grid-cols-4">
@@ -75,9 +75,9 @@ export default function LocationPageTemplate({
                 <h2>Why home staging in {locationName}?</h2>
                 <p>{whyStaging}</p>
 
-                <h2>Our {locationName} services include</h2>
+                <h2>What staging in {locationName} covers</h2>
                 <ul>
-                    {services.map((service) => (
+                    {LOCATION_SERVICES.map((service) => (
                         <li key={service}>{service}</li>
                     ))}
                 </ul>

--- a/src/app/locations/antelope/page.tsx
+++ b/src/app/locations/antelope/page.tsx
@@ -12,7 +12,6 @@ const locationData = {
         'Capital City Staging provides expert home staging services in Antelope, helping you present your property in the best possible light.',
     whyStaging:
         'In Antelope’s competitive market, effective staging can significantly impact your home’s sale. We ensure your property appeals to a broad audience.',
-    services: ['Vacant Home Staging', 'Occupied Home Staging', 'Design Consultations', 'Personalized Staging Solutions'],
     contactText: 'Ready to stage your Antelope home?',
 };
 

--- a/src/app/locations/carmichael/page.tsx
+++ b/src/app/locations/carmichael/page.tsx
@@ -12,7 +12,6 @@ const locationData = {
         'Capital City Staging offers professional home staging services in Carmichael, enhancing your property’s appeal to attract more buyers.',
     whyStaging:
         "Carmichael's charming neighborhoods benefit from staging that showcases each home's unique character. Our services help your property stand out.",
-    services: ['Comprehensive Home Staging', 'Interior Decoration', 'Design Consultations', 'Staging for Luxury Homes'],
     contactText: 'Interested in staging your Carmichael home?',
 };
 

--- a/src/app/locations/citrus-heights/page.tsx
+++ b/src/app/locations/citrus-heights/page.tsx
@@ -12,7 +12,6 @@ const locationData = {
         'Capital City Staging offers professional home staging services in Citrus Heights, enhancing your property’s appeal to attract more buyers.',
     whyStaging:
         'Citrus Heights boasts a vibrant real estate market. Our staging services help your home make a strong impression on potential buyers.',
-    services: ['Comprehensive Home Staging', 'Interior Decoration', 'Design Consultations', 'Customized Styling Plans'],
     contactText: 'Interested in staging your Citrus Heights home?',
 };
 

--- a/src/app/locations/fair-oaks/page.tsx
+++ b/src/app/locations/fair-oaks/page.tsx
@@ -12,7 +12,6 @@ const locationData = {
         'Capital City Staging offers professional home staging services in Fair Oaks, helping your property attract more potential buyers.',
     whyStaging:
         'Fair Oaks’ charming community benefits from staging that highlights each home’s unique character. We make your property stand out.',
-    services: ['Full-Service Home Staging', 'Interior Decoration', 'Design Consultations', 'Personalized Styling Plans'],
     contactText: 'Ready to stage your Fair Oaks home?',
 };
 

--- a/src/app/locations/folsom/page.tsx
+++ b/src/app/locations/folsom/page.tsx
@@ -12,7 +12,6 @@ const locationData = {
         'Capital City Staging is proud to offer premier home staging services in Folsom, California. We help homeowners and real estate agents showcase properties to attract more buyers and achieve higher sale prices.',
     whyStaging:
         "Folsom is a vibrant community with a thriving real estate market. Our home staging services highlight your property's unique features to stand out in this competitive market.",
-    services: ['Vacant Home Staging', 'Occupied Home Staging', 'Home Decoration and Styling', 'Consultations and Assessments'],
     contactText: 'Ready to stage your Folsom home?',
 };
 

--- a/src/app/locations/gold-river/page.tsx
+++ b/src/app/locations/gold-river/page.tsx
@@ -11,7 +11,6 @@ const locationData = {
     description:
         'Capital City Staging provides expert home staging services in Gold River, elevating your property’s appeal to attract discerning buyers.',
     whyStaging: 'Gold River’s upscale market demands exceptional presentation. Our staging services highlight your home’s luxury features.',
-    services: ['Luxury Home Staging', 'Interior Design and Styling', 'Custom Design Solutions', 'Photography Preparation'],
     contactText: 'Looking to enhance your Gold River property?',
 };
 

--- a/src/app/locations/granite-bay/page.tsx
+++ b/src/app/locations/granite-bay/page.tsx
@@ -12,7 +12,6 @@ const locationData = {
         'Capital City Staging offers luxury home staging services in Granite Bay, enhancing your property’s elegance to attract high-end buyers.',
     whyStaging:
         'Granite Bay’s prestigious market requires impeccable presentation. Our staging services showcase your home’s luxury and sophistication.',
-    services: ['Luxury Home Staging', 'Interior Design and Styling', 'Custom Design Solutions', 'Photography Preparation'],
     contactText: 'Looking to elevate your Granite Bay property?',
 };
 

--- a/src/app/locations/locations.constants.ts
+++ b/src/app/locations/locations.constants.ts
@@ -1,0 +1,16 @@
+/**
+ * What every service area actually offers.
+ *
+ * Each location page used to carry its own hand-written list, and between them they advertised
+ * interior decoration, custom design solutions, luxury staging and photography preparation. The
+ * business sells two things — vacant staging and occupied staging — so a prospect could arrive
+ * asking for work that was never on offer. One list, shared by every city, matching the canonical
+ * service pages at `/services/home-staging` and `/services/home-decorating`.
+ */
+export const LOCATION_SERVICES = [
+    'Vacant home staging',
+    'Occupied home staging',
+    'Walkthrough with a room-by-room plan and price',
+    'Furniture install before the photography date',
+    'Removal once the home closes',
+] as const;

--- a/src/app/locations/loomis/page.tsx
+++ b/src/app/locations/loomis/page.tsx
@@ -12,7 +12,6 @@ const locationData = {
         'Capital City Staging provides professional home staging services in Loomis, enhancing your property’s appeal to attract more buyers.',
     whyStaging:
         'Loomis offers a unique blend of rural charm and upscale living. Our staging services highlight the best aspects of your home to captivate buyers.',
-    services: ['Full-Service Home Staging', 'Interior Decoration', 'Design Consultations', 'Personalized Styling Plans'],
     contactText: 'Ready to stage your Loomis home?',
 };
 

--- a/src/app/locations/north-highlands/page.tsx
+++ b/src/app/locations/north-highlands/page.tsx
@@ -12,7 +12,6 @@ const locationData = {
         'Capital City Staging offers professional home staging services in North Highlands, enhancing your property’s appeal to attract more buyers.',
     whyStaging:
         'North Highlands has a dynamic real estate market. Our staging services help your home stand out, making it more attractive to potential buyers.',
-    services: ['Full-Service Home Staging', 'Interior Design Consultation', 'Customized Styling', 'Market-Ready Preparation'],
     contactText: 'Looking to elevate your North Highlands property?',
 };
 

--- a/src/app/locations/orangevale/page.tsx
+++ b/src/app/locations/orangevale/page.tsx
@@ -12,7 +12,6 @@ const locationData = {
         'Capital City Staging provides expert home staging services in Orangevale, making your property more attractive to potential buyers.',
     whyStaging:
         'In Orangevale’s competitive market, effective staging is key to making your home memorable. We highlight your property’s best features.',
-    services: ['Vacant and Occupied Home Staging', 'Interior Design Consultation', 'Customized Styling', 'Market-Ready Preparation'],
     contactText: 'Interested in staging your Orangevale home?',
 };
 

--- a/src/app/locations/rancho-cordova/page.tsx
+++ b/src/app/locations/rancho-cordova/page.tsx
@@ -12,7 +12,6 @@ const locationData = {
         'Capital City Staging offers professional home staging services in Rancho Cordova, helping you present your property in the best possible light to attract potential buyers.',
     whyStaging:
         "Rancho Cordova's real estate market is dynamic and competitive. Our staging services ensure your home stands out, highlighting its best features to maximize appeal.",
-    services: ['Comprehensive Home Staging', 'Interior Decoration', 'Design Consultations', 'Customized Staging Plans'],
     contactText: 'Ready to enhance your Rancho Cordova property?',
 };
 

--- a/src/app/locations/rio-linda/page.tsx
+++ b/src/app/locations/rio-linda/page.tsx
@@ -12,7 +12,6 @@ const locationData = {
         'Capital City Staging provides top-notch home staging services in Rio Linda, helping your property appeal to a wide range of buyers.',
     whyStaging:
         'In Rio Linda, effective home staging can make a significant difference in how quickly and profitably your home sells. We tailor our services to highlight your property’s strengths.',
-    services: ['Vacant and Occupied Home Staging', 'Decorative Enhancements', 'Personalized Staging Plans', 'Photography Preparation'],
     contactText: 'Ready to showcase your Rio Linda home?',
 };
 

--- a/src/app/locations/rocklin/page.tsx
+++ b/src/app/locations/rocklin/page.tsx
@@ -12,12 +12,6 @@ const locationData = {
         'Capital City Staging offers expert home staging services in Rocklin, enhancing your property’s appeal to attract potential buyers.',
     whyStaging:
         'Rocklin’s growing community values homes that are move-in ready. Our staging services help your property meet buyer expectations.',
-    services: [
-        'Vacant and Occupied Home Staging',
-        'Interior Design Consultation',
-        'Customized Styling Solutions',
-        'Photography Preparation',
-    ],
     contactText: 'Interested in staging your Rocklin home?',
 };
 

--- a/src/app/locations/roseville/page.tsx
+++ b/src/app/locations/roseville/page.tsx
@@ -12,7 +12,6 @@ const locationData = {
         'Capital City Staging provides professional home staging services in Roseville, helping your property attract more buyers and sell faster.',
     whyStaging:
         'Roseville’s booming real estate market demands properties that stand out. Our staging services ensure your home makes a lasting impression.',
-    services: ['Full-Service Home Staging', 'Interior Decoration', 'Design Consultations', 'Customized Styling Plans'],
     contactText: 'Ready to enhance your Roseville home?',
 };
 

--- a/src/app/locations/sacramento/page.tsx
+++ b/src/app/locations/sacramento/page.tsx
@@ -12,7 +12,6 @@ const locationData = {
         'Capital City Staging offers premier home staging services in Sacramento, transforming properties to captivate potential buyers and sell faster.',
     whyStaging:
         "Sacramento's real estate market is thriving and competitive. Our professional staging services ensure your property stands out, highlighting its best features to attract more buyers.",
-    services: ['Full-Service Home Staging', 'Interior Decoration and Styling', 'Design Consultations', 'Personalized Staging Strategies'],
     contactText: 'Looking to stage your Sacramento home?',
 };
 

--- a/src/app/locations/west-sacramento/page.tsx
+++ b/src/app/locations/west-sacramento/page.tsx
@@ -12,7 +12,6 @@ const locationData = {
         'Capital City Staging provides expert home staging services in West Sacramento, helping your property shine in a competitive market.',
     whyStaging:
         "West Sacramento's growing real estate scene demands properties that stand out. Our staging services highlight your home's best features to attract potential buyers.",
-    services: ['Vacant Home Staging', 'Occupied Home Staging', 'Interior Design Consultation', 'Customized Styling Solutions'],
     contactText: 'Ready to transform your West Sacramento property?',
 };
 

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -47,7 +47,7 @@ export default function Footer() {
                         Home staging
                     </Link>
                     <Link href="/services/home-decorating" className="hover:text-gold-300 text-sm transition-colors">
-                        Home decorating
+                        Occupied staging
                     </Link>
                     <Link href="/info" className="hover:text-gold-300 text-sm transition-colors">
                         Articles


### PR DESCRIPTION
Sixteen location pages advertised services the business does not sell. Between them they offered interior decoration, interior design and styling, custom design solutions, luxury staging and photography preparation, while the canonical service pages sell exactly two things: vacant staging and occupied staging. A prospect in Gold River or Granite Bay could arrive asking for custom design work that was never on offer, which is a failed sales conversation before any other improvement matters.

## One truthful service list

`LOCATION_SERVICES` in `src/app/locations/locations.constants.ts` is now the single list every city renders:

- Vacant home staging
- Occupied home staging
- Walkthrough with a room-by-room plan and price
- Furniture install before the photography date
- Removal once the home closes

The `services` prop is gone from `LocationPageTemplate`, so a future page cannot reintroduce its own version.

Staging is design work applied to a sale, and the pages still read that way in prose. What they no longer do is list design, decoration or photography as separately purchasable services.

**Kept deliberately:** the per-city market paragraph. It is the only content distinguishing these sixteen pages from one another, and collapsing them into identical pages would cost more than the generic wording does.

## Quoted figures

The homepage claimed `73% less time` and `6-20% higher sale price` with no attribution, and the statistics page listed organisation names without saying which study was being quoted. A seller weighing several thousand dollars of staging against a price reduction is entitled to know that.

Each figure now names its report rather than just the organisation. The `586%` return is labelled as a high reported in one survey rather than a typical result. The statistics page states that these are national survey averages that vary by market and price band, and are not a forecast for a specific listing. The cost article carries the same qualifier instead of repeating the numbers as settled fact. The homepage hero attributes its two numbers and links through to the detail.

## Naming and routing

The footer said `Home decorating` while the page it links to renders `Occupied staging`, which made it read as a third service. The footer now matches the page.

`/admin/projects/[id]/edit` offered a signed-out user a link to `/sign-in`. The route is `/signin`, so that link was a dead end at exactly the moment someone needed it.
