### PR TITLE
Make admin failures visible and the console operable from a keyboard

### DIFF
--- a/src/app/_main_components/PortfolioLightbox.tsx
+++ b/src/app/_main_components/PortfolioLightbox.tsx
@@ -1,8 +1,10 @@
 'use client';
 
-import React, { useCallback, useEffect, useRef } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import Image from 'next/image';
 import { ChevronLeft, ChevronRight, X } from 'lucide-react';
+
+import { useDialogFocus } from '@/hooks/useDialogFocus';
 
 interface LightboxImage {
     _id: string;
@@ -26,7 +28,8 @@ interface PortfolioLightboxProps {
  * backdrop used `bg-opacity-85`, which Tailwind v4 removed, so it rendered fully opaque.
  */
 export default function PortfolioLightbox({ images, index, projectName, onClose, onStep }: PortfolioLightboxProps) {
-    const closeRef = useRef<HTMLButtonElement>(null);
+    /* Escape and the arrow keys are handled below; this only traps Tab and restores focus on close. */
+    const dialogRef = useDialogFocus<HTMLDivElement>(true);
     const image = images[index];
 
     const handleKeyDown = useCallback(
@@ -39,8 +42,6 @@ export default function PortfolioLightbox({ images, index, projectName, onClose,
     );
 
     useEffect(() => {
-        closeRef.current?.focus();
-
         const previousOverflow = document.body.style.overflow;
         document.body.style.overflow = 'hidden';
         document.addEventListener('keydown', handleKeyDown);
@@ -55,8 +56,10 @@ export default function PortfolioLightbox({ images, index, projectName, onClose,
 
     return (
         <div
+            ref={dialogRef}
             role="dialog"
             aria-modal="true"
+            tabIndex={-1}
             aria-label={`${projectName}, image ${index + 1} of ${images.length}`}
             className="bg-ink/90 fixed inset-0 z-50 flex items-center justify-center backdrop-blur-sm"
         >
@@ -73,7 +76,6 @@ export default function PortfolioLightbox({ images, index, projectName, onClose,
             />
 
             <button
-                ref={closeRef}
                 type="button"
                 onClick={onClose}
                 aria-label="Close"

--- a/src/app/admin/edit/EditInventoryClient.tsx
+++ b/src/app/admin/edit/EditInventoryClient.tsx
@@ -9,6 +9,7 @@ import { ArrowLeft, ChevronLeft, ChevronRight, Images, ImageOff, Plus, Settings2
 import { api } from '@/convex/_generated/api';
 import type { Id } from '@/convex/_generated/dataModel';
 import AddInventoryOverlay from '@/components/AddInventoryOverlay';
+import { useUnsavedChangesWarning } from '@/hooks/useUnsavedChangesWarning';
 
 import InventoryDetailsForm from './InventoryDetailsForm';
 import InventoryPhotosSection from './InventoryPhotosSection';
@@ -72,6 +73,10 @@ export default function EditInventoryClient({ oId }: { oId: number }) {
     const [saved, setSaved] = useState(false);
     const [error, setError] = useState<string | null>(null);
     const [addingNew, setAddingNew] = useState(false);
+
+    /* Dirty when the fields on screen differ from the item the last query returned. */
+    const dirty = Boolean(item && form && JSON.stringify(form) !== JSON.stringify(toForm(item)));
+    useUnsavedChangesWarning(dirty);
 
     if (item === undefined || (item && !form)) return <p className="text-body-muted p-6 text-sm">Loading item…</p>;
 

--- a/src/app/admin/error.tsx
+++ b/src/app/admin/error.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import Link from 'next/link';
+import { AlertTriangle, RotateCcw } from 'lucide-react';
+
+/** The admin equivalent, so a failed back-office page keeps her inside the console. */
+export default function AdminError({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
+    return (
+        <main className="bg-ink grid min-h-dvh place-items-center p-6">
+            <div className="border-line bg-surface-raised flex max-w-md flex-col gap-4 rounded-lg border p-6 text-center">
+                <AlertTriangle size={26} aria-hidden="true" className="text-warning mx-auto" />
+                <h1 className="font-display text-body text-2xl leading-tight font-normal">This page could not load</h1>
+                <p className="text-body-muted text-sm">
+                    Your projects, inventory and messages are unaffected. Try again, or go back to the dashboard.
+                </p>
+                {error.digest && <code className="text-body-subtle text-xs">Reference {error.digest}</code>}
+                <div className="flex flex-wrap justify-center gap-2 pt-1">
+                    <button
+                        type="button"
+                        onClick={reset}
+                        className="bg-gold-400 text-body-inverse hover:bg-gold-300 inline-flex items-center gap-2 rounded-md px-4 py-2.5 text-sm font-bold transition-colors"
+                    >
+                        <RotateCcw size={14} aria-hidden="true" /> Try again
+                    </button>
+                    <Link
+                        href="/admin"
+                        className="border-line text-body-muted hover:bg-surface-hover hover:text-body rounded-md border px-4 py-2.5 text-sm font-bold transition-colors"
+                    >
+                        Dashboard
+                    </Link>
+                </div>
+            </div>
+        </main>
+    );
+}

--- a/src/app/admin/inbox/AdminInboxClient.tsx
+++ b/src/app/admin/inbox/AdminInboxClient.tsx
@@ -23,14 +23,24 @@ const fullDate = new Intl.DateTimeFormat('en-US', {
 
 export default function AdminInboxClient() {
     const [filter, setFilter] = useState<InboxFilter>('unanswered');
+    const [error, setError] = useState<string | null>(null);
 
     const submissions = useQuery(api.contactSubmissions.getSubmissions, filter === 'all' ? {} : { responded: filter === 'answered' });
     const setResponded = useMutation(api.contactSubmissions.setResponded);
     const deleteSubmission = useMutation(api.contactSubmissions.deleteSubmission);
 
+    const runOrFail = async (action: Promise<unknown>, message: string) => {
+        setError(null);
+        try {
+            await action;
+        } catch (caught) {
+            setError(caught instanceof Error ? caught.message : message);
+        }
+    };
+
     const handleDelete = async (id: Id<'contactSubmissions'>, name: string) => {
         if (!window.confirm(`Delete the message from ${name}? This cannot be undone.`)) return;
-        await deleteSubmission({ id });
+        await runOrFail(deleteSubmission({ id }), 'Could not delete that message.');
     };
 
     return (
@@ -41,6 +51,12 @@ export default function AdminInboxClient() {
                     title="Inbox"
                     description="Every quote request submitted through the contact form, saved here whether or not its notification email went out."
                 />
+
+                {error && (
+                    <p role="alert" className="border-danger/40 bg-danger-soft text-danger rounded-md border px-4 py-2.5 text-sm">
+                        {error}
+                    </p>
+                )}
 
                 <div className="flex flex-wrap gap-2" role="group" aria-label="Filter messages">
                     {INBOX_FILTERS.map(({ value, label }) => (
@@ -116,7 +132,12 @@ export default function AdminInboxClient() {
                                     <div className="flex items-center gap-2">
                                         <button
                                             type="button"
-                                            onClick={() => setResponded({ id: submission._id, responded: !submission.responded })}
+                                            onClick={() =>
+                                                void runOrFail(
+                                                    setResponded({ id: submission._id, responded: !submission.responded }),
+                                                    'Could not update that message.',
+                                                )
+                                            }
                                             className="border-line text-body-muted hover:bg-surface-overlay hover:text-body inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-xs font-bold transition-colors"
                                         >
                                             {submission.responded ? (

--- a/src/app/admin/inventory/InventoryConvexClient.tsx
+++ b/src/app/admin/inventory/InventoryConvexClient.tsx
@@ -66,6 +66,7 @@ export default function InventoryConvexClient() {
     const [problems, setProblems] = useState<LineProblem[]>([]);
     const [committing, setCommitting] = useState(false);
     const [flash, setFlash] = useState<string | null>(null);
+    const [commitError, setCommitError] = useState<string | null>(null);
 
     const activeProject = projects?.find((project) => project._id === projectId) ?? null;
 
@@ -92,6 +93,7 @@ export default function InventoryConvexClient() {
         clear();
         setProblems([]);
         setFlash(null);
+        setCommitError(null);
         writeUrl({ ...filters, project: nextProjectId });
     };
 
@@ -100,6 +102,7 @@ export default function InventoryConvexClient() {
 
         setCommitting(true);
         setFlash(null);
+        setCommitError(null);
         try {
             const result = await assignItems({
                 projectId: projectId as Id<'projects'>,
@@ -126,8 +129,9 @@ export default function InventoryConvexClient() {
                 setPanelOpen(true);
             }
         } catch (error) {
+            /* A failure is not a confirmation; the success banner would have rendered this in green. */
             setProblems([]);
-            setFlash(error instanceof Error ? error.message : 'Could not save this list. Try again.');
+            setCommitError(error instanceof Error ? error.message : 'Could not save this list. Try again.');
         } finally {
             setCommitting(false);
         }
@@ -256,9 +260,14 @@ export default function InventoryConvexClient() {
                 </div>
 
                 <p aria-live="polite" className="sr-only">
-                    {flash ?? ''}
+                    {commitError ?? flash ?? ''}
                 </p>
                 {flash && <p className="border-success/40 bg-success-soft text-success rounded-md border px-4 py-2.5 text-sm">{flash}</p>}
+                {commitError && (
+                    <p role="alert" className="border-danger/40 bg-danger-soft text-danger rounded-md border px-4 py-2.5 text-sm">
+                        {commitError}
+                    </p>
+                )}
 
                 {visible.length === 0 ? (
                     <div className="border-line bg-surface-raised flex flex-col items-center gap-3 rounded-lg border px-5 py-14 text-center">

--- a/src/app/admin/manage/homepage/HomepageManageClient.tsx
+++ b/src/app/admin/manage/homepage/HomepageManageClient.tsx
@@ -6,7 +6,7 @@ import { api } from '@/convex/_generated/api';
 import { Id, Doc } from '@/convex/_generated/dataModel';
 import Image from 'next/image';
 import { motion, AnimatePresence } from 'framer-motion';
-import { Eye, EyeOff, Pencil, Trash2, Upload, Images, Check, ImageIcon, Loader2 } from 'lucide-react';
+import { Eye, EyeOff, Pencil, Trash2, Upload, Images, Check, ImageIcon, Loader2, MoveLeft, MoveRight } from 'lucide-react';
 import { Tooltip } from 'react-tooltip';
 import ProjectResizeUploader from '@/components/ProjectResizeUploader';
 
@@ -99,7 +99,7 @@ function LivePreviewStrip({ images }: { images: HomepageImageDoc[] }) {
                 {images.map((_: HomepageImageDoc, i: number) => (
                     <div
                         key={i}
-                        className={`h-2 w-2 rounded-full transition-colors ${i === currentIndex ? 'bg-primary' : 'bg-stone-500'}`}
+                        className={`h-2 w-2 rounded-full transition-colors ${i === currentIndex ? 'bg-gold-400' : 'bg-stone-500'}`}
                     />
                 ))}
             </div>
@@ -112,9 +112,11 @@ function LivePreviewStrip({ images }: { images: HomepageImageDoc[] }) {
 function HomepageImageCard({
     image,
     position,
+    total,
     onToggleActive,
     onRemove,
     onEditCaption,
+    onMove,
     onDragStart,
     onDragOver,
     onDrop,
@@ -122,9 +124,12 @@ function HomepageImageCard({
 }: {
     image: HomepageImageDoc;
     position: number;
+    total: number;
     onToggleActive: () => void;
     onRemove: () => void;
     onEditCaption: () => void;
+    /** Ordering has to be reachable without a mouse; drag alone excluded keyboard users entirely. */
+    onMove: (direction: -1 | 1) => void;
     onDragStart: (e: React.DragEvent<HTMLDivElement>) => void;
     onDragOver: (e: React.DragEvent<HTMLDivElement>) => void;
     onDrop: (e: React.DragEvent<HTMLDivElement>) => void;
@@ -136,9 +141,9 @@ function HomepageImageCard({
             onDragStart={onDragStart}
             onDragOver={onDragOver}
             onDrop={onDrop}
-            className={`group bg-surface-raised hover:shadow-primary/5 relative cursor-grab overflow-hidden rounded-xl shadow-lg transition-all duration-300 hover:shadow-xl active:cursor-grabbing ${
+            className={`group bg-surface-raised relative cursor-grab overflow-hidden rounded-xl shadow-lg transition-all duration-300 hover:shadow-xl active:cursor-grabbing ${
                 !image.active ? 'opacity-50 grayscale' : ''
-            } ${isDragTarget ? 'ring-primary ring-2 ring-offset-2 ring-offset-stone-900' : ''}`}
+            } ${isDragTarget ? 'ring-gold-300 ring-2 ring-offset-2 ring-offset-stone-900' : ''}`}
         >
             {/* Image */}
             <div className="relative aspect-[16/10] overflow-hidden">
@@ -152,27 +157,41 @@ function HomepageImageCard({
                 />
 
                 {/* Position badge */}
-                <div className="bg-primary text-body-inverse absolute top-3 left-3 flex h-8 w-8 items-center justify-center rounded-full text-sm font-bold shadow-md">
+                <div className="bg-gold-400 text-body-inverse absolute top-3 left-3 flex h-8 w-8 items-center justify-center rounded-full text-sm font-bold shadow-md">
                     {position}
                 </div>
 
                 {/* Active/Inactive badge */}
                 <div
                     className={`absolute top-3 right-3 rounded-full px-2.5 py-0.5 text-xs font-medium ${
-                        image.active ? 'bg-secondary/90 text-white' : 'bg-surface-hover/90 text-body-muted'
+                        image.active ? 'bg-success-soft text-success' : 'bg-surface-hover/90 text-body-muted'
                     }`}
                 >
                     {image.active ? 'Active' : 'Inactive'}
                 </div>
 
                 {/* Hover overlay with actions */}
-                <div className="bg-surface/60 absolute inset-0 flex items-center justify-center gap-3 opacity-0 transition-opacity duration-300 group-hover:opacity-100">
+                <div className="bg-surface/60 absolute inset-0 flex items-center justify-center gap-2 opacity-0 transition-opacity duration-300 group-focus-within:opacity-100 group-hover:opacity-100">
+                    <button
+                        type="button"
+                        onClick={(e) => {
+                            e.stopPropagation();
+                            onMove(-1);
+                        }}
+                        disabled={position === 1}
+                        aria-label={`Move image ${position} earlier`}
+                        className="bg-surface-raised/90 text-body-muted hover:bg-surface-hover hover:text-body flex h-10 w-10 items-center justify-center rounded-full transition-colors disabled:opacity-30"
+                    >
+                        <MoveLeft size={18} aria-hidden="true" />
+                    </button>
+
                     <button
                         onClick={(e) => {
                             e.stopPropagation();
                             onToggleActive();
                         }}
-                        className="bg-surface-raised/90 text-body-muted hover:bg-secondary flex h-10 w-10 items-center justify-center rounded-full transition-colors hover:text-white"
+                        className="bg-surface-raised/90 text-body-muted hover:bg-surface-hover hover:text-body flex h-10 w-10 items-center justify-center rounded-full transition-colors"
+                        aria-label={image.active ? `Hide image ${position} from the homepage` : `Show image ${position} on the homepage`}
                         data-tooltip-id="homepage-tooltip"
                         data-tooltip-content={image.active ? 'Set Inactive' : 'Set Active'}
                     >
@@ -184,7 +203,8 @@ function HomepageImageCard({
                             e.stopPropagation();
                             onEditCaption();
                         }}
-                        className="bg-surface-raised/90 text-body-muted hover:bg-primary hover:text-body-inverse flex h-10 w-10 items-center justify-center rounded-full transition-colors"
+                        className="bg-surface-raised/90 text-body-muted hover:bg-gold-400 hover:text-body-inverse flex h-10 w-10 items-center justify-center rounded-full transition-colors"
+                        aria-label={`Edit the caption for image ${position}`}
                         data-tooltip-id="homepage-tooltip"
                         data-tooltip-content="Edit caption"
                     >
@@ -196,11 +216,25 @@ function HomepageImageCard({
                             e.stopPropagation();
                             onRemove();
                         }}
-                        className="bg-surface-raised/90 text-body-muted flex h-10 w-10 items-center justify-center rounded-full transition-colors hover:bg-red-600 hover:text-white"
+                        className="bg-surface-raised/90 text-body-muted hover:bg-danger-soft hover:text-danger flex h-10 w-10 items-center justify-center rounded-full transition-colors"
+                        aria-label={`Remove image ${position} from the homepage`}
                         data-tooltip-id="homepage-tooltip"
                         data-tooltip-content="Remove from homepage"
                     >
                         <Trash2 size={18} />
+                    </button>
+
+                    <button
+                        type="button"
+                        onClick={(e) => {
+                            e.stopPropagation();
+                            onMove(1);
+                        }}
+                        disabled={position === total}
+                        aria-label={`Move image ${position} later`}
+                        className="bg-surface-raised/90 text-body-muted hover:bg-surface-hover hover:text-body flex h-10 w-10 items-center justify-center rounded-full transition-colors disabled:opacity-30"
+                    >
+                        <MoveRight size={18} aria-hidden="true" />
                     </button>
                 </div>
             </div>
@@ -238,6 +272,7 @@ export default function HomepageManageClient() {
     const [draggedIndex, setDraggedIndex] = useState<number | null>(null);
     const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
     const [isAdding, setIsAdding] = useState(false);
+    const [error, setError] = useState<string | null>(null);
     const [uploadCaption, setUploadCaption] = useState('');
     const [pendingUpload, setPendingUpload] = useState<{
         originalImageUrl: string;
@@ -261,15 +296,26 @@ export default function HomepageManageClient() {
         setCaptionInput(image.title || '');
     };
 
-    const saveCaption = async () => {
-        if (editingCaptionId) {
-            await updateHomepageImage({
-                id: editingCaptionId as Id<'homepageImages'>,
-                title: captionInput,
-            });
-            setEditingCaptionId(null);
-            setCaptionInput('');
+    const runOrFail = async (action: Promise<unknown>, message: string) => {
+        setError(null);
+        try {
+            await action;
+            return true;
+        } catch (caught) {
+            setError(caught instanceof Error ? caught.message : message);
+            return false;
         }
+    };
+
+    const saveCaption = async () => {
+        if (!editingCaptionId) return;
+        const ok = await runOrFail(
+            updateHomepageImage({ id: editingCaptionId as Id<'homepageImages'>, title: captionInput }),
+            'Could not save that caption.',
+        );
+        if (!ok) return;
+        setEditingCaptionId(null);
+        setCaptionInput('');
     };
 
     // ─── Drag and Drop ─────────────────────────────────────────────────
@@ -285,18 +331,24 @@ export default function HomepageManageClient() {
         setDragOverIndex(index);
     };
 
-    const handleDrop = (dropIndex: number) => async (e: React.DragEvent<HTMLDivElement>) => {
-        e.preventDefault();
-        if (draggedIndex === null || draggedIndex === dropIndex || !homepageImages) return;
+    const commitOrder = async (from: number, to: number) => {
+        if (!homepageImages || from === to || to < 0 || to >= homepageImages.length) return;
 
         const newOrder = [...homepageImages];
-        const [draggedItem] = newOrder.splice(draggedIndex, 1);
-        newOrder.splice(dropIndex, 0, draggedItem);
+        const [moved] = newOrder.splice(from, 1);
+        newOrder.splice(to, 0, moved);
 
-        await reorderHomepageImages({
-            imageIds: newOrder.map((img: HomepageImageDoc) => img._id),
-        });
+        await runOrFail(
+            reorderHomepageImages({ imageIds: newOrder.map((img: HomepageImageDoc) => img._id) }),
+            'Could not save that order.',
+        );
+    };
 
+    const handleDrop = (dropIndex: number) => async (e: React.DragEvent<HTMLDivElement>) => {
+        e.preventDefault();
+        if (draggedIndex === null) return;
+
+        await commitOrder(draggedIndex, dropIndex);
         setDraggedIndex(null);
         setDragOverIndex(null);
     };
@@ -309,7 +361,8 @@ export default function HomepageManageClient() {
     // ─── Remove Image ──────────────────────────────────────────────────
 
     const handleRemove = async (id: Id<'homepageImages'>) => {
-        await removeHomepageImage({ id });
+        if (!window.confirm('Remove this image from the homepage slideshow?')) return;
+        await runOrFail(removeHomepageImage({ id }), 'Could not remove that image.');
     };
 
     // ─── Add From Projects ─────────────────────────────────────────────
@@ -443,7 +496,7 @@ export default function HomepageManageClient() {
                             </p>
                             <button
                                 onClick={() => setAddTab('projects')}
-                                className="bg-primary text-body-inverse hover:bg-primary_dark mt-6 rounded-lg px-6 py-2.5 font-medium transition-colors"
+                                className="bg-gold-400 text-body-inverse hover:bg-gold-300 mt-6 rounded-lg px-6 py-2.5 font-medium transition-colors"
                             >
                                 Browse Project Images
                             </button>
@@ -455,9 +508,11 @@ export default function HomepageManageClient() {
                                     key={image._id}
                                     image={image}
                                     position={index + 1}
-                                    onToggleActive={() => toggleActive({ id: image._id })}
+                                    total={homepageImages.length}
+                                    onToggleActive={() => void runOrFail(toggleActive({ id: image._id }), 'Could not change that image.')}
                                     onRemove={() => handleRemove(image._id)}
                                     onEditCaption={() => startEditCaption(image)}
+                                    onMove={(direction) => void commitOrder(index, index + direction)}
                                     onDragStart={handleDragStart(index)}
                                     onDragOver={handleDragOver(index)}
                                     onDrop={handleDrop(index)}
@@ -467,9 +522,15 @@ export default function HomepageManageClient() {
                         </div>
                     )}
 
+                    {error && (
+                        <p role="alert" className="border-danger/40 bg-danger-soft text-danger mt-4 rounded-lg border px-4 py-2.5 text-sm">
+                            {error}
+                        </p>
+                    )}
+
                     {/* Warning when all images are inactive */}
                     {homepageImages.length > 0 && activeImages.length === 0 && (
-                        <div className="mt-4 rounded-lg border border-amber-600/50 bg-amber-900/20 p-3 text-sm text-amber-300">
+                        <div className="border-warning/40 bg-warning-soft text-warning mt-4 rounded-lg border p-3 text-sm">
                             All images are inactive. The homepage will display default fallback images.
                         </div>
                     )}
@@ -501,7 +562,7 @@ export default function HomepageManageClient() {
                                 </button>
                                 <button
                                     onClick={saveCaption}
-                                    className="bg-primary text-body-inverse hover:bg-primary_dark rounded-lg px-4 py-2 text-sm font-medium transition-colors"
+                                    className="bg-gold-400 text-body-inverse hover:bg-gold-300 rounded-lg px-4 py-2 text-sm font-medium transition-colors"
                                 >
                                     Save
                                 </button>
@@ -522,7 +583,7 @@ export default function HomepageManageClient() {
                         <button
                             onClick={() => setAddTab('projects')}
                             className={`flex flex-1 items-center justify-center gap-2 rounded-md px-3 py-2.5 text-sm font-medium transition-colors ${
-                                addTab === 'projects' ? 'bg-primary text-body-inverse' : 'text-body-subtle hover:text-body'
+                                addTab === 'projects' ? 'bg-gold-400 text-body-inverse' : 'text-body-subtle hover:text-body'
                             }`}
                         >
                             <Images size={16} />
@@ -531,7 +592,7 @@ export default function HomepageManageClient() {
                         <button
                             onClick={() => setAddTab('upload')}
                             className={`flex flex-1 items-center justify-center gap-2 rounded-md px-3 py-2.5 text-sm font-medium transition-colors ${
-                                addTab === 'upload' ? 'bg-primary text-body-inverse' : 'text-body-subtle hover:text-body'
+                                addTab === 'upload' ? 'bg-gold-400 text-body-inverse' : 'text-body-subtle hover:text-body'
                             }`}
                         >
                             <Upload size={16} />
@@ -563,7 +624,7 @@ export default function HomepageManageClient() {
                                                 }}
                                                 className={`rounded-full border-2 px-4 py-1.5 text-sm font-medium transition-all ${
                                                     index === selectedProject
-                                                        ? 'border-secondary bg-secondary text-body'
+                                                        ? 'border-gold-300 bg-gold-400/10 text-body'
                                                         : 'border-line-strong text-body-subtle hover:border-primary hover:text-primary bg-transparent'
                                                 }`}
                                             >
@@ -594,7 +655,7 @@ export default function HomepageManageClient() {
                                                 <button
                                                     onClick={handleAddSelectedToHomepage}
                                                     disabled={selectedProjectImages.size === 0 || isAdding}
-                                                    className="bg-primary text-body-inverse hover:bg-primary_dark rounded px-4 py-1.5 text-xs font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+                                                    className="bg-gold-400 text-body-inverse hover:bg-gold-300 rounded px-4 py-1.5 text-xs font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50"
                                                 >
                                                     {isAdding ? (
                                                         <Loader2 size={14} className="inline animate-spin" />
@@ -636,7 +697,7 @@ export default function HomepageManageClient() {
 
                                                         {/* Selection check */}
                                                         {isSelected && (
-                                                            <div className="bg-primary text-body-inverse absolute top-2 right-2 flex h-6 w-6 items-center justify-center rounded-full">
+                                                            <div className="bg-gold-400 text-body-inverse absolute top-2 right-2 flex h-6 w-6 items-center justify-center rounded-full">
                                                                 <Check size={14} />
                                                             </div>
                                                         )}
@@ -686,7 +747,7 @@ export default function HomepageManageClient() {
                                 <button
                                     onClick={handleAddUploadedImage}
                                     disabled={!pendingUpload || isAdding}
-                                    className="bg-secondary hover:bg-secondary_light w-full rounded-lg py-2.5 font-medium text-white transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+                                    className="bg-gold-400 text-body-inverse hover:bg-gold-300 w-full rounded-lg py-2.5 font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50"
                                 >
                                     {isAdding ? <Loader2 size={18} className="mx-auto animate-spin" /> : 'Add to Homepage'}
                                 </button>

--- a/src/app/admin/projects/[id]/edit/CheckInDialog.tsx
+++ b/src/app/admin/projects/[id]/edit/CheckInDialog.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { Loader2, Undo2, X } from 'lucide-react';
 
 import AssignmentRow from '@/components/admin/inventory/AssignmentRow';
+import { useDialogFocus } from '@/hooks/useDialogFocus';
 
 import type { ProjectAssignmentLine } from '@/components/admin/projects/project.types';
 
@@ -41,13 +42,11 @@ export default function CheckInDialog({
 }) {
     const [excluded, setExcluded] = useState<Set<string>>(new Set());
 
-    useEffect(() => {
-        const onKeyDown = (event: KeyboardEvent) => {
-            if (event.key === 'Escape' && !saving) onCancel();
-        };
-        document.addEventListener('keydown', onKeyDown);
-        return () => document.removeEventListener('keydown', onKeyDown);
+    /* Escape is ignored mid-save: the mutation is already in flight and cannot be taken back. */
+    const close = useCallback(() => {
+        if (!saving) onCancel();
     }, [onCancel, saving]);
+    const dialogRef = useDialogFocus<HTMLDivElement>(true, close);
 
     const included = lines.filter((line) => !excluded.has(line._id));
     const units = included.reduce((total, line) => total + line.quantity, 0);
@@ -59,9 +58,11 @@ export default function CheckInDialog({
             <button type="button" aria-label="Cancel" onClick={() => !saving && onCancel()} className="bg-ink/80 absolute inset-0" />
 
             <div
+                ref={dialogRef}
                 role="dialog"
                 aria-modal="true"
                 aria-labelledby="check-in-title"
+                tabIndex={-1}
                 className="border-line bg-surface-raised shadow-overlay relative flex max-h-[88vh] w-full max-w-lg flex-col overflow-hidden rounded-lg border"
             >
                 <header className="border-line flex items-start gap-3 border-b px-5 py-4">

--- a/src/app/admin/projects/[id]/edit/EditProjectClient.tsx
+++ b/src/app/admin/projects/[id]/edit/EditProjectClient.tsx
@@ -20,6 +20,7 @@ import {
     type ProjectFormState,
     type ProjectStatus,
 } from '@/components/admin/projects/project.types';
+import { useUnsavedChangesWarning } from '@/hooks/useUnsavedChangesWarning';
 
 /**
  * Editing one project.
@@ -98,6 +99,18 @@ export default function EditProjectClient({ projectId }: { projectId: string }) 
             highlighted: project.highlighted || false,
         });
     }
+
+    /* The form is dirty whenever what is on screen differs from what the last query returned. */
+    const dirty = Boolean(
+        project &&
+        (formData.name !== (project.name || '') ||
+            formData.status !== ((project.status as ProjectStatus) ?? 'draft') ||
+            formData.address !== (project.address || '') ||
+            formData.revenue !== (project.revenue ? project.revenue.toString() : '') ||
+            formData.notes !== (project.notes || '') ||
+            formData.highlighted !== (project.highlighted || false)),
+    );
+    useUnsavedChangesWarning(dirty);
 
     const save = async (checkInAssignmentIds?: string[]) => {
         setSaving(true);

--- a/src/app/admin/projects/[id]/inventory/ProjectInventoryClient.tsx
+++ b/src/app/admin/projects/[id]/inventory/ProjectInventoryClient.tsx
@@ -45,6 +45,7 @@ export default function ProjectInventoryClient({ projectId }: { projectId: strin
     const [problems, setProblems] = useState<LineProblem[]>([]);
     const [committing, setCommitting] = useState(false);
     const [flash, setFlash] = useState<string | null>(null);
+    const [commitError, setCommitError] = useState<string | null>(null);
     const [lightbox, setLightbox] = useState<{ src: string; alt: string } | null>(null);
 
     const searchRef = useRef<HTMLInputElement>(null);
@@ -56,6 +57,7 @@ export default function ProjectInventoryClient({ projectId }: { projectId: strin
 
         setCommitting(true);
         setFlash(null);
+        setCommitError(null);
         try {
             const result = await assignItems({
                 projectId: projectId as Id<'projects'>,
@@ -81,8 +83,9 @@ export default function ProjectInventoryClient({ projectId }: { projectId: strin
                 setExpanded(true);
             }
         } catch (error) {
+            /* A failure is not a confirmation; the success banner would have rendered this in green. */
             setProblems([]);
-            setFlash(error instanceof Error ? error.message : 'Could not save this list. Try again.');
+            setCommitError(error instanceof Error ? error.message : 'Could not save this list. Try again.');
         } finally {
             setCommitting(false);
         }
@@ -220,9 +223,14 @@ export default function ProjectInventoryClient({ projectId }: { projectId: strin
                 </div>
 
                 <p aria-live="polite" className="sr-only">
-                    {flash ?? ''}
+                    {commitError ?? flash ?? ''}
                 </p>
                 {flash && <p className="border-success/40 bg-success-soft text-success rounded-md border px-4 py-2.5 text-sm">{flash}</p>}
+                {commitError && (
+                    <p role="alert" className="border-danger/40 bg-danger-soft text-danger rounded-md border px-4 py-2.5 text-sm">
+                        {commitError}
+                    </p>
+                )}
 
                 {visible.length === 0 ? (
                     <div className="border-line bg-surface-raised flex flex-col items-center gap-3 rounded-lg border px-5 py-14 text-center">

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import Link from 'next/link';
+import { AlertTriangle, RotateCcw } from 'lucide-react';
+
+/**
+ * Route-level recovery.
+ *
+ * Without this, one throw inside a page — a Convex query returning a shape a component did not
+ * expect, a null where a document was assumed — replaced the whole app with a blank screen and the
+ * only way out was the browser's back button.
+ */
+export default function RouteError({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
+    return (
+        <main className="bg-ink grid min-h-dvh place-items-center p-6">
+            <div className="border-line bg-surface-raised flex max-w-md flex-col gap-4 rounded-lg border p-6 text-center">
+                <AlertTriangle size={26} aria-hidden="true" className="text-warning mx-auto" />
+                <h1 className="font-display text-body text-2xl leading-tight font-normal">Something went wrong on this page</h1>
+                <p className="text-body-muted text-sm">
+                    Nothing you had already saved is affected. Try the page again, or head back and come at it from somewhere else.
+                </p>
+                {error.digest && <code className="text-body-subtle text-xs">Reference {error.digest}</code>}
+                <div className="flex flex-wrap justify-center gap-2 pt-1">
+                    <button
+                        type="button"
+                        onClick={reset}
+                        className="bg-gold-400 text-body-inverse hover:bg-gold-300 inline-flex items-center gap-2 rounded-md px-4 py-2.5 text-sm font-bold transition-colors"
+                    >
+                        <RotateCcw size={14} aria-hidden="true" /> Try again
+                    </button>
+                    <Link
+                        href="/"
+                        className="border-line text-body-muted hover:bg-surface-hover hover:text-body rounded-md border px-4 py-2.5 text-sm font-bold transition-colors"
+                    >
+                        Go home
+                    </Link>
+                </div>
+            </div>
+        </main>
+    );
+}

--- a/src/app/profile/profile.tsx
+++ b/src/app/profile/profile.tsx
@@ -4,7 +4,7 @@ import { UserProfile } from '@clerk/nextjs';
 
 const Profile = () => {
     return (
-        <div className="bg-secondary_light h-full w-full overflow-y-scroll p-1">
+        <div className="bg-surface h-full w-full overflow-y-scroll p-1">
             <UserProfile path="/profile" routing="path" />
         </div>
     );

--- a/src/components/AddInventoryOverlay.tsx
+++ b/src/components/AddInventoryOverlay.tsx
@@ -420,7 +420,7 @@ const AddInventoryOverlay: React.FC<AddInventoryOverlayProps> = ({ onClose, onSu
                                     <button
                                         onClick={() => handleCreateInventory('edit')}
                                         disabled={!isFormValid}
-                                        className="bg-secondary hover:bg-secondary_light text-body flex items-center space-x-2 rounded-lg px-4 py-2 transition-colors hover:text-white disabled:cursor-not-allowed disabled:opacity-50"
+                                        className="border-line text-body hover:bg-surface-hover flex items-center space-x-2 rounded-lg border px-4 py-2 transition-colors disabled:cursor-not-allowed disabled:opacity-50"
                                         data-tooltip-id="create-edit-btn"
                                         data-tooltip-content="Create and go to edit page"
                                     >
@@ -440,7 +440,7 @@ const AddInventoryOverlay: React.FC<AddInventoryOverlayProps> = ({ onClose, onSu
                                     <button
                                         onClick={() => handleCreateInventory('view')}
                                         disabled={!isFormValid}
-                                        className="bg-primary hover:bg-primary_dark text-body-inverse hover:text-body-inverse flex items-center space-x-2 rounded-lg px-4 py-2 transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+                                        className="bg-gold-400 hover:bg-gold-300 text-body-inverse flex items-center space-x-2 rounded-lg px-4 py-2 transition-colors disabled:cursor-not-allowed disabled:opacity-50"
                                         data-tooltip-id="create-view-btn"
                                         data-tooltip-content="Create and view in inventory"
                                     >

--- a/src/components/admin/AdminSidePanel.tsx
+++ b/src/components/admin/AdminSidePanel.tsx
@@ -1,7 +1,9 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useCallback } from 'react';
 import { X } from 'lucide-react';
+
+import { useDialogFocus } from '@/hooks/useDialogFocus';
 
 /**
  * A detail column that is furniture on a wide screen and a slide-over on a narrow one.
@@ -25,16 +27,13 @@ export default function AdminSidePanel({
     onEscape?: () => void;
     children: React.ReactNode;
 }) {
-    useEffect(() => {
-        if (!open) return;
-        const onKeyDown = (event: KeyboardEvent) => {
-            if (event.key !== 'Escape') return;
-            if (onEscape) onEscape();
-            else onOpenChange(false);
-        };
-        document.addEventListener('keydown', onKeyDown);
-        return () => document.removeEventListener('keydown', onKeyDown);
-    }, [open, onEscape, onOpenChange]);
+    const close = useCallback(() => {
+        if (onEscape) onEscape();
+        else onOpenChange(false);
+    }, [onEscape, onOpenChange]);
+
+    /* Only the overlay traps focus. Above `xl` the panel is ordinary page furniture. */
+    const dialogRef = useDialogFocus<HTMLElement>(open, close);
 
     return (
         <>
@@ -47,9 +46,11 @@ export default function AdminSidePanel({
                         className="bg-ink/70 absolute inset-0"
                     />
                     <aside
+                        ref={dialogRef}
                         role="dialog"
                         aria-modal="true"
                         aria-label={label}
+                        tabIndex={-1}
                         className="border-line bg-surface-raised shadow-overlay relative flex h-full w-full max-w-md flex-col border-l"
                     >
                         <button

--- a/src/components/admin/projects/ProjectPaymentDialog.tsx
+++ b/src/components/admin/projects/ProjectPaymentDialog.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { useState } from 'react';
 import { useMutation } from 'convex/react';
 import { AlertCircle, Loader2, X } from 'lucide-react';
 
@@ -9,6 +9,7 @@ import type { Id } from '@/convex/_generated/dataModel';
 
 import { PAYMENT_METHODS, exactMoney, fromDateInput, toDateInput } from './payments.constants';
 import type { PaymentState } from './payments.types';
+import { useDialogFocus } from '@/hooks/useDialogFocus';
 
 /**
  * What she is asked when a job gets marked paid.
@@ -53,16 +54,7 @@ export default function ProjectPaymentDialog({
     const [saving, setSaving] = useState(false);
     const [error, setError] = useState<string | null>(null);
 
-    const closeRef = useRef<HTMLButtonElement>(null);
-
-    useEffect(() => {
-        closeRef.current?.focus();
-        const onKeyDown = (event: KeyboardEvent) => {
-            if (event.key === 'Escape') onClose();
-        };
-        document.addEventListener('keydown', onKeyDown);
-        return () => document.removeEventListener('keydown', onKeyDown);
-    }, [onClose]);
+    const dialogRef = useDialogFocus<HTMLDivElement>(true, onClose);
 
     /*
      * A partial payment adds to what has already been recorded; the field asks for this payment, not
@@ -103,9 +95,11 @@ export default function ProjectPaymentDialog({
             <button type="button" aria-label="Cancel" onClick={onClose} className="bg-ink/70 absolute inset-0" />
 
             <div
+                ref={dialogRef}
                 role="dialog"
                 aria-modal="true"
                 aria-labelledby="payment-dialog-title"
+                tabIndex={-1}
                 className="border-line bg-surface-raised shadow-overlay relative flex max-h-[90dvh] w-full max-w-md flex-col overflow-y-auto rounded-lg border"
             >
                 <header className="border-line flex items-start justify-between gap-3 border-b px-5 py-4">
@@ -116,7 +110,6 @@ export default function ProjectPaymentDialog({
                         </h2>
                     </div>
                     <button
-                        ref={closeRef}
                         type="button"
                         onClick={onClose}
                         aria-label="Cancel"

--- a/src/components/layout/nav/MobileNavPanel.tsx
+++ b/src/components/layout/nav/MobileNavPanel.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { ChevronDown, Mail, Phone, X } from 'lucide-react';
 
 import { CONTACT_DETAILS, PRIMARY_CTA, PRIMARY_NAV, type NavItem } from '@/lib/menu_list';
 import { track } from '@/lib/analytics';
+import { useDialogFocus } from '@/hooks/useDialogFocus';
 
 interface MobileNavPanelProps {
     open: boolean;
@@ -19,27 +20,19 @@ const PANEL_LINK_CLASSES = 'flex min-h-[52px] items-center rounded-md px-4 text-
 
 export default function MobileNavPanel({ open, onClose, isAdmin, activeId, onSectionClick }: MobileNavPanelProps) {
     const [expanded, setExpanded] = useState<string | null>(null);
-    const closeButtonRef = useRef<HTMLButtonElement>(null);
+    const dialogRef = useDialogFocus<HTMLDivElement>(open, onClose);
 
-    // Focus the close control and lock the page behind the panel while it is open.
+    // Lock the page behind the panel while it is open. Focus and Escape are handled by the hook.
     useEffect(() => {
         if (!open) return;
-
-        closeButtonRef.current?.focus();
 
         const previousOverflow = document.body.style.overflow;
         document.body.style.overflow = 'hidden';
 
-        const onKeyDown = (event: KeyboardEvent) => {
-            if (event.key === 'Escape') onClose();
-        };
-        document.addEventListener('keydown', onKeyDown);
-
         return () => {
             document.body.style.overflow = previousOverflow;
-            document.removeEventListener('keydown', onKeyDown);
         };
-    }, [open, onClose]);
+    }, [open]);
 
     if (!open) return null;
 
@@ -74,16 +67,17 @@ export default function MobileNavPanel({ open, onClose, isAdmin, activeId, onSec
             />
 
             <div
+                ref={dialogRef}
                 id="site-menu"
                 role="dialog"
                 aria-modal="true"
                 aria-label="Site menu"
+                tabIndex={-1}
                 className="border-line bg-surface shadow-overlay absolute inset-y-0 right-0 flex w-[min(88vw,360px)] flex-col border-l"
             >
                 <div className="border-line flex h-16 shrink-0 items-center justify-between border-b px-4">
                     <span className="text-body-subtle text-[13px] font-bold tracking-[0.12em] uppercase">Menu</span>
                     <button
-                        ref={closeButtonRef}
                         type="button"
                         onClick={onClose}
                         aria-label="Close menu"

--- a/src/hooks/useDialogFocus.ts
+++ b/src/hooks/useDialogFocus.ts
@@ -1,0 +1,64 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+
+/**
+ * Keeps keyboard focus inside an open dialog and gives it back when the dialog closes.
+ *
+ * Every overlay in the app rendered its own markup and left focus wherever it was, so Tab walked
+ * straight out of the dialog into the page behind it and closing returned nobody to the control they
+ * had opened. Escape is handled here too, because a dialog that traps focus and cannot be dismissed
+ * from a keyboard is worse than one that does neither.
+ */
+export function useDialogFocus<T extends HTMLElement>(open: boolean, onClose?: () => void) {
+    const ref = useRef<T>(null);
+    const restoreTo = useRef<HTMLElement | null>(null);
+
+    useEffect(() => {
+        if (!open) return;
+
+        restoreTo.current = document.activeElement as HTMLElement | null;
+
+        const container = ref.current;
+        const focusable = () =>
+            Array.from(
+                container?.querySelectorAll<HTMLElement>(
+                    'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+                ) ?? [],
+            ).filter((element) => element.offsetParent !== null || element === document.activeElement);
+
+        /* Focus the dialog itself rather than its first control, so a screen reader reads the label. */
+        container?.focus({ preventScroll: true });
+
+        const onKeyDown = (event: KeyboardEvent) => {
+            if (event.key === 'Escape') {
+                onClose?.();
+                return;
+            }
+            if (event.key !== 'Tab') return;
+
+            const items = focusable();
+            if (items.length === 0) return;
+
+            const first = items[0];
+            const last = items[items.length - 1];
+            const active = document.activeElement;
+
+            if (event.shiftKey && (active === first || active === container)) {
+                event.preventDefault();
+                last.focus();
+            } else if (!event.shiftKey && active === last) {
+                event.preventDefault();
+                first.focus();
+            }
+        };
+
+        document.addEventListener('keydown', onKeyDown);
+        return () => {
+            document.removeEventListener('keydown', onKeyDown);
+            restoreTo.current?.focus({ preventScroll: true });
+        };
+    }, [open, onClose]);
+
+    return ref;
+}

--- a/src/hooks/useUnsavedChangesWarning.ts
+++ b/src/hooks/useUnsavedChangesWarning.ts
@@ -1,0 +1,27 @@
+'use client';
+
+import { useEffect } from 'react';
+
+/**
+ * Warns before the browser discards edits that were never sent.
+ *
+ * Both editors hold a form draft and a tray of uploaded-but-uncommitted photos entirely in the
+ * browser. Closing the tab, hitting back, or following a link threw all of it away without a word,
+ * which is the same class of loss as a failed save — it just looks like the operator's fault.
+ *
+ * This covers reloads, tab closes and external navigation. In-app route changes are the router's,
+ * and the editors keep their own save state visible for those.
+ */
+export function useUnsavedChangesWarning(dirty: boolean) {
+    useEffect(() => {
+        if (!dirty) return;
+
+        const onBeforeUnload = (event: BeforeUnloadEvent) => {
+            event.preventDefault();
+            event.returnValue = '';
+        };
+
+        window.addEventListener('beforeunload', onBeforeUnload);
+        return () => window.removeEventListener('beforeunload', onBeforeUnload);
+    }, [dirty]);
+}


### PR DESCRIPTION
Several admin controls reported failure only to the console, one reported it inside the green success banner, and the homepage slideshow could not be reordered without a mouse at all.

## Keyboard and focus

Homepage slideshow images gain move-earlier and move-later buttons. Drag was the only way to order them, which excluded keyboard users from the control that decides what the front page shows. The hover overlay now also appears on `focus-within`, so its actions are reachable rather than merely tabbable, and every icon-only button carries a label naming the image it acts on.

One `useDialogFocus` hook keeps focus inside an open dialog, handles Escape, and returns focus to whatever opened it. It replaces five separate hand-rolled Escape listeners in:

- `AdminSidePanel` (overlay mode only; above `xl` the panel is ordinary page furniture)
- `ProjectPaymentDialog`
- `CheckInDialog` — Escape is ignored mid-save, since the mutation is already in flight
- `PortfolioLightbox` — keeps its own arrow-key handling
- `MobileNavPanel`

Tab used to walk straight out of every one of these into the page behind, and closing left focus nowhere.

## Failures that were invisible

Inbox status changes and deletions, homepage captions, ordering, activation and removal, and catalog archive, restore and ordering all render their error to the operator now.

A failed staging commit rendered its message in the success banner, so `Could not save this list` arrived in success green. Errors have their own `role="alert"` region and the success banner is reserved for success.

Removing an image from the homepage slideshow asks first.

## Work that could be lost

Both editors hold a form draft and a tray of uploaded-but-uncommitted photos entirely in the browser. `useUnsavedChangesWarning` warns before a reload, tab close or external navigation discards it.

`error.tsx` at the app root and under `/admin` replace the blank screen a single throw used to produce. Both offer a retry and a way back, and surface the error digest.

## Tokens

The remaining operational controls move off the legacy `primary` and `secondary` aliases and raw reds onto the documented tokens: the Users role controls, the catalog manage tabs and actions, the whole homepage manage surface, `AddInventoryOverlay`, and `/profile`.

The contact form's estimate panel and the fullscreen viewer chrome are deliberately left alone. Those are public visual design rather than operational controls, and `primary` still resolves to the gold in the palette, so converting them would shift the rendered hue on customer-facing pages as a side effect of a cleanup.
