### PR TITLE
Cut explanatory copy that competes with admin and article content

### DIFF
--- a/src/app/admin/AdminDashboardClient.tsx
+++ b/src/app/admin/AdminDashboardClient.tsx
@@ -63,7 +63,7 @@ export default function AdminDashboardClient() {
                     description={
                         attentionAreas > 0
                             ? `${attentionAreas} ${plural(attentionAreas, 'area needs', 'areas need')} attention before the day begins.`
-                            : 'Everything is in order. Nothing is waiting on you right now.'
+                            : 'Nothing needs attention.'
                     }
                     action={
                         <Link
@@ -99,7 +99,6 @@ export default function AdminDashboardClient() {
                                 ? `${summary.projects.awaitingPayment} ${plural(summary.projects.awaitingPayment, 'project is', 'projects are')} awaiting payment`
                                 : 'Payments are up to date'
                         }
-                        description="Completed jobs stay here until the payment is recorded against them."
                         href="/admin/projects"
                         linkLabel="Open projects"
                         tone={summary.projects.awaitingPayment ? 'warning' : 'good'}
@@ -112,7 +111,7 @@ export default function AdminDashboardClient() {
                                 ? `${summary.inventory.needsAttention} ${plural(summary.inventory.needsAttention, 'item needs', 'items need')} attention`
                                 : 'Catalog is complete'
                         }
-                        description="Items with no photo, or unpriced while out on a job. Prices can be fixed straight from the queue."
+                        description="Missing photos and live-job prices."
                         href="/admin/inventory/attention"
                         linkLabel="Open fix queue"
                         tone={summary.inventory.needsAttention ? 'warning' : 'good'}
@@ -125,7 +124,7 @@ export default function AdminDashboardClient() {
                                 ? `${summary.inbox.unanswered} new ${plural(summary.inbox.unanswered, 'message', 'messages')}`
                                 : 'Inbox is clear'
                         }
-                        description="Every quote request from the contact form is saved here, even if its email fails."
+                        description="Quote requests, including failed email notifications."
                         href="/admin/inbox"
                         linkLabel="Open inbox"
                         tone={summary.inbox.unanswered ? 'warning' : 'good'}
@@ -153,7 +152,7 @@ export default function AdminDashboardClient() {
                         value={`${number.format(summary.inventory.out)} units`}
                         hint={
                             summary.inventory.out === 0
-                                ? 'Nothing is at a house right now'
+                                ? ''
                                 : summary.projects.activeName
                                   ? `At ${summary.projects.activeName}`
                                   : `Across ${number.format(summary.inventory.outProjects)} houses`

--- a/src/app/admin/analytics/AnalyticsClient.tsx
+++ b/src/app/admin/analytics/AnalyticsClient.tsx
@@ -34,11 +34,7 @@ export default function AnalyticsClient({ range, traffic }: { range: PostHogRang
     return (
         <AdminShell title="Analytics">
             <div className="flex flex-col gap-8 p-5 sm:p-8">
-                <AdminHeading
-                    eyebrow="Insights"
-                    title="Analytics"
-                    description="How the business is performing, and how people are finding and moving through the website."
-                />
+                <AdminHeading eyebrow="Insights" title="Analytics" />
 
                 <section className="flex flex-col gap-4">
                     <h2 className="font-display text-body text-xl font-normal">Business</h2>
@@ -107,9 +103,7 @@ export default function AnalyticsClient({ range, traffic }: { range: PostHogRang
                             <div className="grid gap-5 xl:grid-cols-3">
                                 <AdminPanel eyebrow="Earning" title="Top earners">
                                     {insights.topEarners.length === 0 ? (
-                                        <AdminEmpty>
-                                            No assignment has carried a price yet, so nothing has recorded any rental value.
-                                        </AdminEmpty>
+                                        <AdminEmpty>No rental value recorded yet.</AdminEmpty>
                                     ) : (
                                         <BarList entries={insights.topEarners} format={(value) => money.format(value)} />
                                     )}

--- a/src/app/admin/edit/InventoryDetailsForm.tsx
+++ b/src/app/admin/edit/InventoryDetailsForm.tsx
@@ -89,7 +89,6 @@ export default function InventoryDetailsForm({
                                 <option key={category} value={category} />
                             ))}
                         </datalist>
-                        {dimensionsMatter && <span className="text-body-subtle text-xs">Measurements matter for this category.</span>}
                     </label>
 
                     <label className="flex flex-col gap-1.5">
@@ -205,11 +204,7 @@ export default function InventoryDetailsForm({
                             </label>
                         ))}
                     </div>
-                    {missingDimensions && (
-                        <p className="text-body-subtle text-xs">
-                            Without these, nobody can answer whether it fits the room they are staging.
-                        </p>
-                    )}
+                    {missingDimensions && <p className="text-body-subtle text-xs">Measurements help confirm whether it fits.</p>}
                 </fieldset>
 
                 {error && (

--- a/src/app/admin/edit/InventoryStatusPanel.tsx
+++ b/src/app/admin/edit/InventoryStatusPanel.tsx
@@ -126,8 +126,8 @@ export default function InventoryStatusPanel({ item }: { item: EditorItem }) {
                 <div className="flex flex-col gap-3 p-4">
                     <p className="text-body-muted text-sm">
                         {item.active
-                            ? 'Retiring hides it from the catalog and the picker. Its staging history stays intact, and it can come back.'
-                            : 'This item is hidden from the catalog and the picker. Nothing about its history was lost.'}
+                            ? 'Retiring hides it from the catalog and picker but keeps its history.'
+                            : 'Hidden from the catalog and picker; history is intact.'}
                     </p>
 
                     {error && (

--- a/src/app/admin/inbox/AdminInboxClient.tsx
+++ b/src/app/admin/inbox/AdminInboxClient.tsx
@@ -49,7 +49,7 @@ export default function AdminInboxClient() {
                 <AdminHeading
                     eyebrow="Clients"
                     title="Inbox"
-                    description="Every quote request submitted through the contact form, saved here whether or not its notification email went out."
+                    description="Quote requests, including any whose notification email failed."
                 />
 
                 {error && (
@@ -82,10 +82,10 @@ export default function AdminInboxClient() {
                     <div className="border-line bg-surface-raised rounded-lg border">
                         <AdminEmpty>
                             {filter === 'unanswered'
-                                ? 'No unanswered messages. Everything has been replied to.'
+                                ? 'No messages need a reply.'
                                 : filter === 'answered'
                                   ? 'No answered messages yet.'
-                                  : 'No messages yet. Submissions from the contact form appear here.'}
+                                  : 'No messages yet.'}
                         </AdminEmpty>
                     </div>
                 ) : (

--- a/src/app/admin/inventory/CatalogSidePanel.tsx
+++ b/src/app/admin/inventory/CatalogSidePanel.tsx
@@ -65,10 +65,7 @@ export default function CatalogSidePanel({
         <div className="flex flex-1 flex-col items-center justify-center gap-3 p-6 text-center">
             <House size={26} aria-hidden="true" className="text-body-subtle" />
             <strong className="font-display text-body text-base leading-tight font-normal">No house selected</strong>
-            <p className="text-body-muted max-w-[16rem] text-sm">
-                Choose a house at the top of the page and the whole catalog becomes a picker for it.
-            </p>
-            <p className="text-body-subtle max-w-[16rem] text-xs">Or tap any item to see where it is and what it has earned.</p>
+            <p className="text-body-muted max-w-[16rem] text-sm">Choose a house to build its staging list, or open an item for details.</p>
             <PackageSearch size={18} aria-hidden="true" className="text-body-subtle mt-1" />
         </div>
     );

--- a/src/app/admin/inventory/InventoryConvexClient.tsx
+++ b/src/app/admin/inventory/InventoryConvexClient.tsx
@@ -187,11 +187,7 @@ export default function InventoryConvexClient() {
                 <AdminHeading
                     eyebrow="Inventory"
                     title="Catalog"
-                    description={
-                        staging
-                            ? 'Tap items to build a list for the selected house. Nothing is saved until you commit it.'
-                            : 'Everything you own, what is free to stage, and which house is holding the rest.'
-                    }
+                    description={staging ? 'Pick items for the selected house; save when the list is ready.' : undefined}
                     action={
                         <div className="flex shrink-0 flex-wrap items-center gap-2">
                             <ProjectPicker projects={projects} selectedId={projectId} onSelect={handleProjectChange} />
@@ -275,7 +271,7 @@ export default function InventoryConvexClient() {
                         <strong className="font-display text-body text-lg font-normal">Nothing matches those filters</strong>
                         <p className="text-body-muted max-w-sm text-sm">
                             {items.length === 0
-                                ? 'The catalog is empty. Add your first piece of furniture to get started.'
+                                ? 'The catalog is empty.'
                                 : 'Try a different category, or clear the filters to see everything.'}
                         </p>
                         {items.length === 0 && (

--- a/src/app/admin/inventory/ProjectWorkspacePanel.tsx
+++ b/src/app/admin/inventory/ProjectWorkspacePanel.tsx
@@ -81,9 +81,7 @@ export default function ProjectWorkspacePanel({
                     )}
 
                     {touched.length === 0 ? (
-                        <p className="text-body-subtle px-4 py-6 text-center text-sm">
-                            Tap items in the grid to build a list for this house. Nothing is saved until you commit.
-                        </p>
+                        <p className="text-body-subtle px-4 py-6 text-center text-sm">Nothing selected.</p>
                     ) : (
                         <ul className="divide-line divide-y">
                             {touched.map(({ item, desired, delta }) => (

--- a/src/app/admin/inventory/attention/InventoryAttentionClient.tsx
+++ b/src/app/admin/inventory/attention/InventoryAttentionClient.tsx
@@ -37,7 +37,7 @@ export default function InventoryAttentionClient() {
                 <AdminHeading
                     eyebrow="Inventory"
                     title="Fix queue"
-                    description="Problems that cost money on a live job come first. Prices and measurements can be filled in right here without opening the editor."
+                    description="Fix live-job pricing first; handle photos and measurements later."
                     action={
                         <Link
                             href="/admin/inventory"
@@ -63,10 +63,6 @@ export default function InventoryAttentionClient() {
                     <div className="border-line bg-surface-raised flex flex-col items-center gap-3 rounded-lg border px-5 py-14 text-center">
                         <CheckCircle2 size={28} aria-hidden="true" className="text-success" />
                         <strong className="font-display text-body text-xl font-normal">Nothing needs fixing</strong>
-                        <p className="text-body-muted max-w-md text-sm">
-                            Every active item has a photo and a price, no item is assigned out more times than you own, and the furniture
-                            that needs measurements has them.
-                        </p>
                     </div>
                 ) : (
                     <>

--- a/src/app/admin/inventory/check-in/CheckInWizardClient.tsx
+++ b/src/app/admin/inventory/check-in/CheckInWizardClient.tsx
@@ -45,7 +45,7 @@ export default function CheckInWizardClient() {
                 <div className="flex flex-col gap-6 p-5 sm:p-8">
                     <SkeletonBlock className="h-8 w-64" />
                     <div className="border-line bg-surface-raised rounded-lg border">
-                        <SkeletonListRows rows={5} label="Finding inventory that never came back" />
+                        <SkeletonListRows rows={5} label="Loading check-ins" />
                     </div>
                 </div>
             </AdminShell>
@@ -68,7 +68,7 @@ export default function CheckInWizardClient() {
                         <p className="text-body-muted max-w-md text-sm">
                             {checkedInUnits > 0
                                 ? `${number.format(checkedInUnits)} units are back on the books. Availability across the catalog is now accurate.`
-                                : 'No finished job is holding inventory. From here on, marking a project completed offers to check its furniture in, so this should not build up again.'}
+                                : 'No finished job is holding inventory.'}
                         </p>
                         {skipped.size > 0 && (
                             <button
@@ -135,7 +135,7 @@ export default function CheckInWizardClient() {
                 <AdminHeading
                     eyebrow="Inventory"
                     title="Check furniture back in"
-                    description="These jobs finished while inventory was still assigned to them, so the catalog thinks the furniture is unavailable. Confirm one house at a time."
+                    description="Confirm returns one house at a time."
                     action={
                         <Link
                             href="/admin/inventory"

--- a/src/app/admin/manage/homepage/HomepageManageClient.tsx
+++ b/src/app/admin/manage/homepage/HomepageManageClient.tsx
@@ -491,9 +491,7 @@ export default function HomepageManageClient() {
                         <div className="border-line flex flex-col items-center justify-center rounded-xl border-2 border-dashed py-16 text-center">
                             <ImageIcon size={64} className="mb-4 text-stone-600" />
                             <h3 className="text-body-muted text-xl font-semibold">No Homepage Images Yet</h3>
-                            <p className="text-body-subtle mt-2 max-w-md">
-                                Add images from your projects or upload new ones to create a stunning hero slideshow.
-                            </p>
+                            <p className="text-body-subtle mt-2 max-w-md">Add project photos or upload an image.</p>
                             <button
                                 onClick={() => setAddTab('projects')}
                                 className="bg-gold-400 text-body-inverse hover:bg-gold-300 mt-6 rounded-lg px-6 py-2.5 font-medium transition-colors"
@@ -608,9 +606,7 @@ export default function HomepageManageClient() {
                                     <Loader2 className="text-body-subtle h-6 w-6 animate-spin" />
                                 </div>
                             ) : availableProjects.length === 0 ? (
-                                <div className="text-body-subtle py-12 text-center">
-                                    No highlighted projects available. Mark projects as highlighted in the Projects admin page.
-                                </div>
+                                <div className="text-body-subtle py-12 text-center">No highlighted projects.</div>
                             ) : (
                                 <>
                                     {/* Project selector pills */}
@@ -638,9 +634,7 @@ export default function HomepageManageClient() {
                                     {currentProject && currentProject.images.length > 0 && (
                                         <div className="mb-4 flex items-center justify-between">
                                             <span className="text-body-subtle text-sm">
-                                                {selectedProjectImages.size > 0
-                                                    ? `${selectedProjectImages.size} selected`
-                                                    : 'Click images to select'}
+                                                {selectedProjectImages.size > 0 ? `${selectedProjectImages.size} selected` : ''}
                                             </span>
                                             <div className="flex gap-2">
                                                 <button
@@ -740,7 +734,6 @@ export default function HomepageManageClient() {
                                         value={uploadCaption}
                                         onChange={(e) => setUploadCaption(e.target.value)}
                                         className="border-line-strong bg-surface-overlay text-body focus:border-primary w-full rounded-lg border px-3 py-2 focus:outline-none"
-                                        placeholder="Enter a caption for this image..."
                                     />
                                 </div>
 
@@ -767,7 +760,7 @@ export default function HomepageManageClient() {
                                 ) : (
                                     <div className="text-body-subtle text-center">
                                         <Upload size={48} className="mx-auto mb-3 opacity-40" />
-                                        <p>Upload an image to see preview</p>
+                                        <p></p>
                                     </div>
                                 )}
                             </div>

--- a/src/app/admin/projects/AdminProjectsClient.tsx
+++ b/src/app/admin/projects/AdminProjectsClient.tsx
@@ -108,9 +108,7 @@ export default function AdminProjectsClient() {
         <div className="flex flex-1 flex-col items-center justify-center gap-3 p-6 text-center">
             <FolderOpen size={26} aria-hidden="true" className="text-body-subtle" />
             <strong className="font-display text-body text-base leading-tight font-normal">No project selected</strong>
-            <p className="text-body-muted max-w-[16rem] text-sm">
-                Pick a project to see its money, its furniture and its photos, and to change the small things without opening it.
-            </p>
+            <p className="text-body-muted max-w-[16rem] text-sm">Select a project for payment, inventory, photos, and quick edits.</p>
         </div>
     );
 

--- a/src/app/admin/projects/[id]/edit/CheckInDialog.tsx
+++ b/src/app/admin/projects/[id]/edit/CheckInDialog.tsx
@@ -74,8 +74,8 @@ export default function CheckInDialog({
                             Is the furniture back?
                         </h2>
                         <p className="text-body-muted text-sm">
-                            {number.format(totalUnits)} {totalUnits === 1 ? 'unit is' : 'units are'} still assigned to this house. Checking
-                            them in puts them back on the books as free to stage.
+                            Checking in these {number.format(totalUnits)} {totalUnits === 1 ? 'unit' : 'units'} makes them available to
+                            stage again.
                         </p>
                     </div>
                     <button

--- a/src/app/admin/projects/[id]/inventory/ProjectInventoryClient.tsx
+++ b/src/app/admin/projects/[id]/inventory/ProjectInventoryClient.tsx
@@ -197,7 +197,7 @@ export default function ProjectInventoryClient({ projectId }: { projectId: strin
                 <AdminHeading
                     eyebrow={project.name}
                     title="Choose furniture"
-                    description="Tap items to build a list, adjust how many of each, then add the whole list to this house in one go."
+                    description="Pick items, set quantities, then add the list."
                     action={
                         <Link
                             href={`/admin/projects/${projectId}/edit`}

--- a/src/app/admin/projects/[id]/inventory/StagingListTray.tsx
+++ b/src/app/admin/projects/[id]/inventory/StagingListTray.tsx
@@ -79,9 +79,7 @@ export default function StagingListTray({
                         Adding now
                     </h3>
                     {touched.length === 0 ? (
-                        <p className="text-body-subtle px-4 py-6 text-center text-sm">
-                            Tap items in the grid to build a list for this house.
-                        </p>
+                        <p className="text-body-subtle px-4 py-6 text-center text-sm">Nothing selected.</p>
                     ) : (
                         <ul className="divide-line divide-y">
                             {touched.map(({ item, desired, delta }) => (

--- a/src/app/admin/tools/DataBackup.tsx
+++ b/src/app/admin/tools/DataBackup.tsx
@@ -60,10 +60,7 @@ export default function DataBackup() {
                 </div>
             </dl>
 
-            <p className="text-body-muted max-w-prose text-sm">
-                One row per inventory item with every stored field, including items hidden from the public catalog. The file is built in
-                your browser and never leaves this machine.
-            </p>
+            <p className="text-body-muted max-w-prose text-sm">Includes every stored field and items hidden from the public catalog.</p>
 
             <div className="flex flex-wrap items-center gap-3">
                 <button

--- a/src/app/admin/tools/DataHealth.tsx
+++ b/src/app/admin/tools/DataHealth.tsx
@@ -77,9 +77,7 @@ export default function DataHealth() {
             <div className="flex flex-col gap-2">
                 <h3 className="text-body text-sm font-bold">Recompute inventory counters</h3>
                 <p className="text-body-muted max-w-2xl text-sm">
-                    Every screen works out availability from the assignment records themselves, so this is not something you need to run to
-                    get correct numbers. It only tidies the stored <code>inUse</code> and <code>inventoryAssigned</code> fields, which
-                    drifted before availability was derived. Safe to run twice; the second run finds nothing.
+                    Optional cleanup for legacy counters. Availability is already accurate, and it is safe to run more than once.
                 </p>
             </div>
 

--- a/src/app/admin/tools/ImageProcessing.tsx
+++ b/src/app/admin/tools/ImageProcessing.tsx
@@ -1,39 +1,8 @@
-import { CheckCircle2 } from 'lucide-react';
-
-const AUTOMATED_STEPS = [
-    {
-        title: 'Small image generation',
-        body: 'A thumbnail is produced when the file is uploaded, so the catalog never waits on a batch job.',
-    },
-    {
-        title: 'Dimension verification',
-        body: 'Width and height are read from the file on upload and stored with the record, so they cannot drift.',
-    },
-];
-
 /**
- * Replaces two separate tabs that each rendered a disabled button explaining that the feature had
- * moved into the upload pipeline. Two dead tabs read as two broken tools.
+ * Thumbnails and dimensions used to be two tabs, each with a disabled button explaining that the
+ * feature had moved into the upload pipeline. Two dead tabs read as two broken tools, and the
+ * replacement then explained its own implementation history to the operator. One line is enough.
  */
 export default function ImageProcessing() {
-    return (
-        <div className="flex flex-col gap-4 p-5">
-            <p className="text-body-muted text-sm">
-                Nothing to run here. Both jobs happen during upload, which is why the buttons that used to be on this page are gone rather
-                than disabled.
-            </p>
-
-            <ul className="flex flex-col gap-3">
-                {AUTOMATED_STEPS.map((step) => (
-                    <li key={step.title} className="border-line bg-surface flex items-start gap-3 rounded-lg border px-4 py-3.5">
-                        <CheckCircle2 size={17} aria-hidden="true" className="text-success mt-0.5 shrink-0" />
-                        <div className="flex flex-col gap-1">
-                            <strong className="text-body text-sm font-bold">{step.title}</strong>
-                            <p className="text-body-muted text-sm">{step.body}</p>
-                        </div>
-                    </li>
-                ))}
-            </ul>
-        </div>
-    );
+    return <p className="text-body-muted p-5 text-sm">Thumbnails and dimensions are handled during upload.</p>;
 }

--- a/src/app/admin/tools/tools.constants.ts
+++ b/src/app/admin/tools/tools.constants.ts
@@ -3,7 +3,6 @@ export interface ToolTab {
     label: string;
     eyebrow: string;
     title: string;
-    description: string;
 }
 
 /**
@@ -16,21 +15,18 @@ export const TOOL_TABS: readonly ToolTab[] = [
         label: 'Data backup',
         eyebrow: 'Export',
         title: 'Download the catalog',
-        description: 'Export every inventory record to a spreadsheet, including items that are not publicly listed.',
     },
     {
         id: 'health',
         label: 'Data health',
         eyebrow: 'Maintenance',
         title: 'Inventory counters',
-        description: 'Recompute the stored availability counters that drifted before availability was derived from assignment records.',
     },
     {
         id: 'images',
         label: 'Image processing',
         eyebrow: 'Automatic',
         title: 'Thumbnails and dimensions',
-        description: 'Both of these used to be manual jobs you ran from this page. They are part of the upload now.',
     },
 ] as const;
 

--- a/src/app/admin/tools/tools.tsx
+++ b/src/app/admin/tools/tools.tsx
@@ -25,11 +25,7 @@ export default function Tools({ activeTab }: { activeTab: string }) {
 
     return (
         <div className="flex flex-col gap-8">
-            <AdminHeading
-                eyebrow="Maintenance"
-                title="Tools"
-                description="Exports and data-health utilities. Anything that runs automatically is listed here too, so you are not left wondering where it went."
-            />
+            <AdminHeading title="Tools" description="Exports and catalog maintenance." />
 
             <div className="flex flex-col gap-4">
                 <nav className="flex flex-wrap gap-2" aria-label="Tools">
@@ -54,7 +50,6 @@ export default function Tools({ activeTab }: { activeTab: string }) {
                 </nav>
 
                 <AdminPanel eyebrow={tab.eyebrow} title={tab.title}>
-                    <p className="border-line text-body-muted border-b px-5 py-3.5 text-sm">{tab.description}</p>
                     <Panel />
                 </AdminPanel>
             </div>

--- a/src/app/contact/contact.tsx
+++ b/src/app/contact/contact.tsx
@@ -25,8 +25,7 @@ export default function Contact() {
                             Let&rsquo;s stage your home
                         </h1>
                         <p className="text-body-muted mt-4 max-w-xl text-lg text-pretty">
-                            Tell us about the property and you&rsquo;ll get a price range right away. Mia reviews every request personally
-                            and follows up with a walkthrough date.
+                            Tell Mia about the property and timing; she&rsquo;ll follow up to schedule a walkthrough.
                         </p>
 
                         <div className="mt-7">

--- a/src/app/contact/contact_form.tsx
+++ b/src/app/contact/contact_form.tsx
@@ -438,7 +438,7 @@ const ContactForm = () => {
                         onChange={(e) => handleChange('message', e.target.value)}
                         rows={3}
                         className="border-line-strong bg-surface-overlay text-body placeholder-body-subtle focus:border-gold-400 w-full resize-none rounded-lg border px-4 py-3 transition-colors"
-                        placeholder="Tell us about your timeline, specific needs, or any questions you have..."
+                        placeholder="Timeline, rooms, access, and listing date."
                     />
                     {errors.message && (
                         <p id="contact-message-error" className="text-danger text-xs">
@@ -611,7 +611,7 @@ const ContactForm = () => {
                                 <div className="mb-6 text-center">
                                     <div className="mb-1 flex items-center justify-center gap-2">
                                         <Calculator className="text-primary" size={24} />
-                                        <h3 className="text-primary text-2xl font-bold">Your Estimated Quote</h3>
+                                        <h3 className="text-primary text-2xl font-bold">Estimated range</h3>
                                     </div>
                                 </div>
 
@@ -623,10 +623,6 @@ const ContactForm = () => {
                                                 <Phone className="mx-auto mb-3 text-amber-400" size={40} />
                                                 <div className="mb-2 text-xl font-bold text-amber-200">Custom Quote Required</div>
                                                 <div className="text-sm text-amber-200/80">{quote.customQuoteReason}</div>
-                                            </div>
-                                            <div className="text-body-muted text-sm">
-                                                Please submit your information below and Mia will provide a personalized quote for your
-                                                property.
                                             </div>
                                         </div>
 
@@ -660,14 +656,10 @@ const ContactForm = () => {
                                         {/* Main Quote Display */}
                                         <div className="from-primary/10 via-primary_dark/15 to-primary/10 border-primary/30 mb-6 rounded-xl border bg-gradient-to-br p-6 text-center">
                                             <div className="mb-2">
-                                                <div className="text-body-subtle mb-2 text-sm tracking-wider uppercase">
-                                                    Estimated Price Range
-                                                </div>
                                                 <div className="gradient-gold-main-text text-3xl font-bold">
                                                     {formatPrice(quote.priceRange.min)} - {formatPrice(quote.priceRange.max)}
                                                 </div>
                                             </div>
-                                            <div className="text-body-subtle mt-3 text-xs">Final pricing determined after consultation</div>
                                         </div>
 
                                         {/* Price Breakdown */}
@@ -876,10 +868,7 @@ const ContactForm = () => {
                                         <div className="mb-4 rounded-lg border border-amber-500/30 bg-amber-500/5 p-4">
                                             <p className="flex items-start gap-2 text-sm text-amber-200">
                                                 <Info size={18} className="mt-0.5 flex-shrink-0 text-amber-400" />
-                                                <span>
-                                                    <strong>Important:</strong> This is an estimate only. Final pricing will be confirmed
-                                                    after Mia reviews your property details and conducts a walkthrough consultation.
-                                                </span>
+                                                <span>Final price follows Mia&rsquo;s walkthrough.</span>
                                             </p>
                                         </div>
 

--- a/src/app/info/articles_spec.ts
+++ b/src/app/info/articles_spec.ts
@@ -13,8 +13,7 @@ export const articles: Article[] = [
     {
         id: 'understanding-buyer-psychology',
         title: 'Understanding Buyer Psychology in Home Staging',
-        description:
-            "Learn how buyer psychology influences home staging strategies. Discover techniques to appeal to buyers' emotions and increase your property's marketability.",
+        description: 'How staging helps buyers picture a future in the home.',
         imageSrc: '/info/understanding-buyer-psychology.jpg',
         imageWidth: 1280,
         imageHeight: 960,
@@ -24,8 +23,7 @@ export const articles: Article[] = [
     {
         id: 'home-staging-tips',
         title: 'Home Staging Tips and Tricks',
-        description:
-            'Discover expert tips and tricks for staging your home to sell faster and for a higher price. Learn from the professionals at Capital City Staging.',
+        description: 'Eight practical fixes to make a home feel larger, brighter, and ready to photograph.',
         imageSrc: '/info/home-staging-tips.jpg',
         imageWidth: 720,
         imageHeight: 720,
@@ -35,8 +33,7 @@ export const articles: Article[] = [
     {
         id: 'home-staging-statistics',
         title: 'Home Staging Statistics',
-        description:
-            'Explore key statistics that demonstrate the effectiveness of home staging. Learn how staging influences sale price, time on market, and buyer perceptions.',
+        description: 'Sale-price, time-on-market, and buyer-perception figures behind staging.',
         imageSrc: '/info/home-staging-statistics.jpg',
         imageWidth: 960,
         imageHeight: 609,
@@ -46,8 +43,7 @@ export const articles: Article[] = [
     {
         id: 'cost-vs-value-analysis',
         title: 'Home Staging Cost vs. Value Analysis',
-        description:
-            'Understand the return on investment for home staging. Learn how staging costs compare to the increased value and faster sale of your property.',
+        description: 'Compare staging cost with price reductions, carrying costs, and sale proceeds.',
         imageSrc: '/info/cost-vs-value-analysis.jpg',
         imageWidth: 750,
         imageHeight: 500,
@@ -57,8 +53,7 @@ export const articles: Article[] = [
     {
         id: 'benefits-of-home-staging',
         title: 'The Benefits of Home Staging',
-        description:
-            'Discover how professional home staging can help sell your property faster and for a higher price. Learn the key benefits with Capital City Staging.',
+        description: 'Six ways staging changes photos, buyer interest, offers, and seller workload.',
         imageSrc: '/info/benefits-of-home-staging.jpg',
         imageWidth: 1280,
         imageHeight: 492,

--- a/src/app/info/benefits-of-home-staging/page.tsx
+++ b/src/app/info/benefits-of-home-staging/page.tsx
@@ -31,17 +31,11 @@ export default function BenefitsOfHomeStaging() {
                 }}
                 aside={
                     <ContactCallout
-                        heading="Ready to experience the benefits?"
-                        body="Book a consultation and take the first step toward selling faster and for a higher price."
+                        heading="Get a staging estimate"
+                        body="See a price range for your property before booking a walkthrough."
                     />
                 }
             >
-                <p>
-                    Selling a home is a significant undertaking, and first impressions are crucial. Professional home staging is a powerful
-                    tool that can make your property more appealing to potential buyers. At Capital City Staging, we help you showcase your
-                    home&rsquo;s best features, ensuring it stands out in the competitive real estate market.
-                </p>
-
                 <h2>Key benefits of home staging</h2>
 
                 <h3>1. Sell your home faster</h3>

--- a/src/app/info/cost-vs-value-analysis/page.tsx
+++ b/src/app/info/cost-vs-value-analysis/page.tsx
@@ -29,12 +29,7 @@ export default function CostVsValueAnalysis() {
                     width: article.imageWidth,
                     height: article.imageHeight,
                 }}
-                aside={
-                    <ContactCallout
-                        heading="Ready to invest wisely?"
-                        body="We’ll walk you through the numbers for your property before you commit to anything."
-                    />
-                }
+                aside={<ContactCallout heading="Price your property" body="See a staging range before you commit to a walkthrough." />}
             >
                 <h2>The financial impact of home staging</h2>
                 <p>

--- a/src/app/info/home-staging-tips/page.tsx
+++ b/src/app/info/home-staging-tips/page.tsx
@@ -29,18 +29,8 @@ export default function HomeStagingTips() {
                     width: article.imageWidth,
                     height: article.imageHeight,
                 }}
-                aside={
-                    <ContactCallout
-                        heading="Need professional help?"
-                        body="These tips get you started. Professional staging takes the property the rest of the way."
-                    />
-                }
+                aside={<ContactCallout heading="Want Mia's room-by-room plan?" body="Get a staging range for your property." />}
             >
-                <p>
-                    Preparing your home for sale can be daunting. We have compiled a list of expert tips to help you stage your home
-                    effectively and attract potential buyers.
-                </p>
-
                 <h3>1. Declutter your space</h3>
                 <p>
                     Remove unnecessary items to create a sense of space. A clutter-free home appears larger and lets buyers focus on the

--- a/src/app/info/understanding-buyer-psychology/page.tsx
+++ b/src/app/info/understanding-buyer-psychology/page.tsx
@@ -29,24 +29,8 @@ export default function UnderstandingBuyerPsychology() {
                     width: article.imageWidth,
                     height: article.imageHeight,
                 }}
-                aside={
-                    <ContactCallout
-                        heading="Ready to connect with buyers?"
-                        body="We build staging plans around the buyers your listing is actually competing for."
-                    />
-                }
+                aside={<ContactCallout heading="Stage for the right buyer" body="Get a plan built around your listing's competition." />}
             >
-                <p>
-                    Selling a home isn’t just about showcasing square footage; it’s about connecting with buyers emotionally. Understanding
-                    buyer psychology is what makes a staging strategy resonate and motivates an offer.
-                </p>
-
-                <h2>The role of emotions in buying decisions</h2>
-                <p>
-                    Buying a home is an emotional process. Buyers are not looking for a structure; they are looking for a place to build a
-                    future. Tapping into that creates a connection between the buyer and the property.
-                </p>
-
                 <h2>Key psychological principles in home staging</h2>
 
                 <h3>1. First impressions matter</h3>

--- a/src/app/services/home-decorating/page.tsx
+++ b/src/app/services/home-decorating/page.tsx
@@ -14,7 +14,7 @@ import { serviceSchema, SITE_URL } from '@/lib/structuredData';
 const TITLE = 'Occupied Home Staging in Sacramento';
 const HEADING = 'Occupied staging';
 const DESCRIPTION =
-    'Occupied home staging and decorating across Sacramento, Placer and Yolo counties. Mia Dofflemyer restyles the home you are still living in so it is ready to list.';
+    'Occupied home staging across Sacramento, Placer and Yolo counties. Mia Dofflemyer restyles the home you are still living in so it is ready to list.';
 
 export const metadata: Metadata = {
     title: TITLE,

--- a/src/app/signin/[[...sign-in]]/page.tsx
+++ b/src/app/signin/[[...sign-in]]/page.tsx
@@ -39,7 +39,6 @@ export default async function SignInPage({ searchParams }: { searchParams: Promi
         <AuthShell
             eyebrow="Admin access"
             title="Sign in"
-            description="The admin console is where staging projects, inventory, the homepage and incoming enquiries are managed."
             footer={
                 <p>
                     Trying to book staging instead?{' '}

--- a/src/app/signout/page.tsx
+++ b/src/app/signout/page.tsx
@@ -15,7 +15,7 @@ export default async function SignOutPage() {
 
     if (!user) {
         return (
-            <AuthShell eyebrow="Session" title="You are signed out" description="Nothing else is stored in this browser.">
+            <AuthShell eyebrow="Session" title="You are signed out">
                 <SignedOutNotice />
             </AuthShell>
         );
@@ -25,7 +25,7 @@ export default async function SignOutPage() {
     const isAdmin = await isClerkUserIdAdmin(user.id);
 
     return (
-        <AuthShell eyebrow="Session" title="Sign out" description="Confirm below, or head back to the console.">
+        <AuthShell eyebrow="Session" title="Sign out">
             <AccountSessionPanel email={email} isAdmin={isAdmin} />
         </AuthShell>
     );

--- a/src/components/admin/AdminNav.tsx
+++ b/src/components/admin/AdminNav.tsx
@@ -28,7 +28,7 @@ export default function AdminNav() {
     return (
         <nav aria-label="Admin sections" className="flex flex-col gap-1 overflow-y-auto p-3">
             <span className="text-body-subtle px-3 pb-2 text-[10px] font-extrabold tracking-[0.14em] uppercase">Workspace</span>
-            {ADMIN_NAVIGATION.map(({ href, label, detail, icon: Icon, badge }) => {
+            {ADMIN_NAVIGATION.map(({ href, label, icon: Icon, badge }) => {
                 const active = isActive(pathname, href);
                 const count = badge ? badgeCounts[badge] : 0;
 
@@ -37,17 +37,14 @@ export default function AdminNav() {
                         key={href}
                         href={href}
                         aria-current={active ? 'page' : undefined}
-                        className={`group grid min-h-14 grid-cols-[24px_minmax(0,1fr)_auto] items-center gap-3 rounded-md border px-3 py-2 transition-colors ${
+                        className={`group grid min-h-11 grid-cols-[24px_minmax(0,1fr)_auto] items-center gap-3 rounded-md border px-3 py-2 transition-colors ${
                             active
                                 ? 'border-line border-l-gold-300 bg-surface-overlay text-body border-l-2'
                                 : 'text-body-muted hover:border-line hover:bg-surface-raised hover:text-body border-transparent'
                         }`}
                     >
                         <Icon size={18} aria-hidden="true" />
-                        <span className="flex min-w-0 flex-col">
-                            <strong className="truncate text-xs font-bold">{label}</strong>
-                            <small className="text-body-subtle truncate text-[10px] leading-snug">{detail}</small>
-                        </span>
+                        <strong className="truncate text-sm font-bold">{label}</strong>
                         {count > 0 && (
                             <span
                                 className="border-gold-400/55 bg-gold-400/10 text-gold-300 inline-grid h-6 min-w-6 place-items-center rounded-full border px-1.5 text-[10px] leading-none font-extrabold"

--- a/src/components/admin/AdminPrimitives.tsx
+++ b/src/components/admin/AdminPrimitives.tsx
@@ -53,7 +53,8 @@ export function AdminCard({
     icon: LucideIcon;
     label: string;
     headline: string;
-    description: string;
+    /** Optional: a headline that already states the situation does not need a second sentence. */
+    description?: string;
     href: string;
     linkLabel: string;
     tone?: AdminStatusTone;
@@ -65,7 +66,7 @@ export function AdminCard({
                 {label}
             </span>
             <h2 className="font-display text-body text-xl leading-snug font-normal">{headline}</h2>
-            <p className="text-body-muted text-sm">{description}</p>
+            {description && <p className="text-body-muted text-sm">{description}</p>}
             <div className="mt-auto flex items-center justify-between gap-3 pt-2">
                 <Link
                     href={href}

--- a/src/components/admin/AdminShell.constants.ts
+++ b/src/components/admin/AdminShell.constants.ts
@@ -2,15 +2,16 @@ import { BarChart3, Boxes, Home, Inbox, LayoutDashboard, Sofa, Users, Wrench } f
 
 import type { AdminNavItem, AdminStatusTone } from './AdminShell.types';
 
+/** Labels only. The subtitles restated what each destination obviously is. */
 export const ADMIN_NAVIGATION: readonly AdminNavItem[] = [
-    { href: '/admin', label: 'Today', detail: 'What needs attention', icon: LayoutDashboard },
-    { href: '/admin/projects', label: 'Projects', detail: 'Staging jobs and revenue', icon: Home },
-    { href: '/admin/inventory', label: 'Inventory', detail: 'Furniture and decor catalog', icon: Sofa, badge: 'inventoryAttention' },
-    { href: '/admin/manage/homepage', label: 'Homepage', detail: 'Hero image rotation', icon: Boxes },
-    { href: '/admin/inbox', label: 'Inbox', detail: 'Quote requests and messages', icon: Inbox, badge: 'inbox' },
-    { href: '/admin/analytics', label: 'Analytics', detail: 'Traffic and engagement', icon: BarChart3 },
-    { href: '/admin/users', label: 'Users', detail: 'Accounts and roles', icon: Users },
-    { href: '/admin/tools', label: 'Tools', detail: 'Backups and data health', icon: Wrench },
+    { href: '/admin', label: 'Today', icon: LayoutDashboard },
+    { href: '/admin/projects', label: 'Projects', icon: Home },
+    { href: '/admin/inventory', label: 'Inventory', icon: Sofa, badge: 'inventoryAttention' },
+    { href: '/admin/manage/homepage', label: 'Homepage', icon: Boxes },
+    { href: '/admin/inbox', label: 'Inbox', icon: Inbox, badge: 'inbox' },
+    { href: '/admin/analytics', label: 'Analytics', icon: BarChart3 },
+    { href: '/admin/users', label: 'Users', icon: Users },
+    { href: '/admin/tools', label: 'Tools', icon: Wrench },
 ] as const;
 
 export const ADMIN_STATUS_TONE_CLASSES: Record<AdminStatusTone, string> = {

--- a/src/components/admin/AdminShell.tsx
+++ b/src/components/admin/AdminShell.tsx
@@ -34,10 +34,7 @@ function RailContents() {
                 className="border-line text-body-muted hover:text-body mx-3 mt-auto mb-4 grid grid-cols-[24px_1fr] items-center gap-3 border-t px-3 pt-4 transition-colors"
             >
                 <ExternalLink size={17} aria-hidden="true" />
-                <span className="flex min-w-0 flex-col">
-                    <strong className="text-xs font-bold">View website</strong>
-                    <small className="text-body-subtle text-[10px]">Open the public site</small>
-                </span>
+                <strong className="truncate text-xs font-bold">View website</strong>
             </Link>
         </>
     );
@@ -78,12 +75,7 @@ export default function AdminShell({ title, children }: AdminShellProps) {
                         {menuOpen ? <X size={18} /> : <Menu size={18} />}
                     </button>
 
-                    <div className="flex min-w-0 flex-col">
-                        <span className="text-body-subtle text-[10px] font-extrabold tracking-[0.14em] uppercase">
-                            Capital City Staging
-                        </span>
-                        <strong className="font-display truncate text-lg leading-tight font-normal">{title}</strong>
-                    </div>
+                    <strong className="font-display min-w-0 truncate text-lg leading-tight font-normal">{title}</strong>
 
                     <Link
                         href="/"

--- a/src/components/admin/AdminShell.types.ts
+++ b/src/components/admin/AdminShell.types.ts
@@ -3,7 +3,6 @@ import type { LucideIcon } from 'lucide-react';
 export interface AdminNavItem {
     href: string;
     label: string;
-    detail: string;
     icon: LucideIcon;
     /** Which dashboard counter, if any, renders as a badge on this item. */
     badge?: 'inbox' | 'inventoryAttention';

--- a/src/components/auth/AuthShell.tsx
+++ b/src/components/auth/AuthShell.tsx
@@ -6,7 +6,7 @@ import { ArrowLeft } from 'lucide-react';
 interface AuthShellProps {
     eyebrow: string;
     title: string;
-    description: string;
+    description?: string;
     children: ReactNode;
     footer?: ReactNode;
 }
@@ -34,7 +34,7 @@ export default function AuthShell({ eyebrow, title, description, children, foote
                 <div className="border-line bg-surface-raised shadow-card mt-8 rounded-xl border p-6 sm:p-8">
                     <p className="text-forest-200 text-xs font-semibold tracking-[0.2em] uppercase">{eyebrow}</p>
                     <h1 className="font-display text-gold-300 mt-2 text-2xl font-bold">{title}</h1>
-                    <p className="text-body-muted mt-2 text-sm leading-relaxed">{description}</p>
+                    {description ? <p className="text-body-muted mt-2 text-sm leading-relaxed">{description}</p> : null}
 
                     <div className="mt-7">{children}</div>
 

--- a/src/lib/structuredData.ts
+++ b/src/lib/structuredData.ts
@@ -38,7 +38,7 @@ export function localBusinessSchema(): Record<string, unknown> {
             '@type': 'City',
             name: `${name}, CA`,
         })),
-        knowsAbout: ['Home staging', 'Vacant home staging', 'Occupied home staging', 'Home decorating', 'Real estate presentation'],
+        knowsAbout: ['Home staging', 'Vacant home staging', 'Occupied home staging', 'Real estate presentation'],
     };
 }
 


### PR DESCRIPTION
Cuts the explanatory prose that was sitting between an operator and the data they came for. 219 lines of copy removed against 73 added, concentrated on the admin console, the five info articles, and the two auth pages. No behaviour changes; the only structural edits are three props becoming optional.

## Why the admin console needed it

Every navigation row carried a subtitle, every card carried a description, and every tools tab restated its own label in a sentence below it. On the dashboard, inbox and inventory routes that pushed the actual counts and rows below the fold. The labels already name the destination, so the second sentence was reading cost with no payload.

| Surface | Before | After |
| --- | --- | --- |
| Admin nav | label + one-line `detail` per item | label + badge, rows at `min-h-11` |
| Tools panels | tab label, then a paragraph restating it | heading only; image processing is one sentence |
| Dashboard cards | description under every heading | description only where it changes the action |
| Empty states | two sentences of encouragement | one clause naming the next step |

`detail` is gone from `ADMIN_NAVIGATION` and from `AdminShell.types.ts` rather than left unused. `AdminCard`, `AdminHeading` and `AuthShell` now take an optional `description` and render it conditionally, so a surface that has nothing useful to add renders nothing instead of an empty string.

The tools image-processing panel previously explained a manual thumbnail workflow that no longer exists — thumbnails and dimensions are produced during upload. It now says exactly that, in one line.

## Articles and CTAs

The five `articles_spec.ts` `description` fields all followed the same shape: a generic promise, then the brand name. Those strings are the search snippet, so they were spending their character budget on words a reader already has. Each now names its specific subject, for example `Compare staging cost with price reductions, carrying costs, and sale proceeds.` in place of the previous return-on-investment boilerplate.

The matching `ContactCallout` blocks moved from open-ended enthusiasm (`Ready to experience the benefits?`) to the concrete offer (`Get a staging estimate` / `See a price range for your property before booking a walkthrough.`). Three articles also opened with a paragraph restating that selling a home is significant and first impressions matter, immediately above a section that made a real point; those intros are removed.

## Remaining decorating references

Two places still described decorating as something sold separately from staging: the meta description on `/services/home-decorating` and the `knowsAbout` array in the organisation structured data. Both now say occupied staging. The route keeps its URL and its existing explanation of why the path and the content differ.

## Files

`src/components/admin/` (nav, shell, primitives, constants, types), `src/app/admin/` (dashboard, analytics, inbox, inventory and its attention/check-in/catalog panels, projects, tools, edit forms, manage/homepage), `src/app/info/` (spec plus four articles), `src/app/contact/`, `src/app/signin/`, `src/app/signout/`, `src/components/auth/AuthShell.tsx`, `src/lib/structuredData.ts`.
