### PR TITLE
Document the Clerk instance and admin-check tradeoffs

### DIFF
--- a/DEPLOYMENTS.md
+++ b/DEPLOYMENTS.md
@@ -62,3 +62,64 @@ someone remembering to run the script.
 Compare the source and destination snapshots rather than trusting the import summary. For each
 table, both the row count and the set of `_id` values should match, and no `projectInventory` or
 `projectImages` row should reference a `projectId` that is absent from `projects`.
+
+## Authentication
+
+Production runs against a Clerk **development** instance (`immense-stinkbug-94.clerk.accounts.dev`,
+publishable key `pk_test_*`). This is a deliberate deferral, not an oversight. Moving to a Clerk
+production instance requires provisioning a production domain and SSO credentials, and the reasons
+to hurry do not currently apply.
+
+Admin access does not depend on which instance is in use. Two independent gates gate it, and both
+fail closed:
+
+1. `src/proxy.ts` requires Clerk membership in an organisation named `ADMIN` with the `org:admin`
+   role. Anyone else is redirected to `/not-authorized`.
+2. Convex `isAdmin` / `requireAdmin` in `convex/authz.ts` require `users.role === "admin"`. New
+   users are created as `"customer"` (`convex/users.ts`).
+
+A stranger who signs up gets neither, so test keys do not expose the console.
+
+### What the development instance does cost
+
+| Limit       | Development                                     | Production          |
+| ----------- | ----------------------------------------------- | ------------------- |
+| Users       | 100, and **not transferable between instances** | No cap              |
+| Backend API | 100 requests / 10s                              | 1000 requests / 10s |
+| Emails      | 100 / month                                     | Standard            |
+
+The usual reason to migrate early is the non-transferable user cap: accounts created on a
+development instance cannot be moved, so the longer it runs the more there is to lose. That does not
+apply here. There are three users, all admins, and no customer-facing account feature — `/profile`
+is a stub and `getUserProjects` in `convex/projects.ts` has no UI consumer. The debt is not growing.
+
+### Open sign-up
+
+`/signup` is publicly reachable and linked from the sign-in component via `signUpUrl="/signup"`,
+even though accounts do nothing for customers; leads arrive through the contact form. This is
+accepted for now.
+
+The risk is not privilege escalation, which the two gates above cover. It is the development
+instance's quotas: junk sign-ups consume the 100-user cap and the 100-emails-per-month allowance,
+and an exhausted email quota could stop Mia's own sign-in emails from sending. Unlikely, and
+annoying to diagnose if it happens.
+
+To close it without a deploy, set sign-up mode to restricted in the Clerk dashboard under
+Restrictions. To close it in code, remove `src/app/signup/` and drop `signUpUrl` from the `<SignIn />`
+element in `src/app/signin/[[...sign-in]]/page.tsx`.
+
+### `isClerkUserIdAdmin` calls the Clerk API on every admin request
+
+`src/utils/auth/ClerkUtils.ts` resolves admin status by fetching the user's organisation memberships
+from the Clerk Backend API, and `src/proxy.ts` calls it for every request whose path starts with
+`/admin`. Every admin page load and client-side navigation therefore costs a round trip to Clerk
+before anything renders.
+
+This is knowingly accepted at the current scale. One operator is nowhere near the development
+instance's 100 requests per 10 seconds, so it is a latency cost rather than a correctness problem.
+It is, however, the first thing that would hit a wall under real load, and it is the reason admin
+navigation feels slower than the rest of the site.
+
+The fix, when it is worth doing, is to stop asking Clerk on every request: put the admin claim in
+the session token via a Clerk JWT template or session claim and read it from `auth()`, which keeps
+the check local to the edge.

--- a/src/app/signin/[[...sign-in]]/page.tsx
+++ b/src/app/signin/[[...sign-in]]/page.tsx
@@ -49,6 +49,11 @@ export default async function SignInPage({ searchParams }: { searchParams: Promi
                 </p>
             }
         >
+            {/*
+                `signUpUrl` leaves public sign-up reachable even though accounts do nothing for
+                customers. Kept for now; the two admin gates make it a quota concern rather than an
+                access one. See DEPLOYMENTS.md, "Authentication".
+            */}
             <SignIn path="/signin" routing="path" signUpUrl="/signup" fallbackRedirectUrl={returnTo} appearance={authAppearance} />
         </AuthShell>
     );

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -14,6 +14,8 @@ export default clerkMiddleware(async (auth, req) => {
             return NextResponse.redirect(signIn);
         }
 
+        // One Clerk Backend API round trip per admin request. See DEPLOYMENTS.md, "Authentication",
+        // for why that is accepted for now and what replaces it.
         const hasAdminRole = await isClerkUserIdAdmin(userId);
         if (!hasAdminRole) {
             return NextResponse.redirect(new URL('/not-authorized', req.url));

--- a/src/utils/auth/ClerkUtils.ts
+++ b/src/utils/auth/ClerkUtils.ts
@@ -22,6 +22,15 @@ async function captureClerkUserOrganizationMemberships(userId: string) {
     }
 }
 
+/**
+ * Resolves admin status by asking the Clerk Backend API for the user's organisation memberships.
+ *
+ * `src/proxy.ts` calls this for every request under `/admin`, so each admin page load and
+ * navigation costs a round trip to Clerk before anything renders. That is accepted at one operator
+ * — well inside the development instance's 100 requests per 10 seconds — but it is a latency cost
+ * on every request and the first limit that real load would reach. Moving the admin claim into the
+ * session token would keep the check at the edge. See DEPLOYMENTS.md, "Authentication".
+ */
 export async function isClerkUserIdAdmin(userId: string) {
     let isAdmin = false;
     if (userId) {


### PR DESCRIPTION
Documentation only — no behaviour changes. Records two accepted tradeoffs in the auth path that currently look like oversights to anyone encountering them cold, so the next person to find them does not have to re-derive whether they are bugs.

## Clerk development instance in production

Production authenticates against a Clerk development instance (`pk_test_*`). Keeping it is a deliberate deferral.

The usual reason to migrate early is that development instances cap at 100 users and those accounts **cannot be transferred between instances**, so every day of delay adds accounts you will eventually have to recreate. That pressure does not apply here: there are three users, all admins, and no customer-facing account feature at all. `/profile` is a stub and `getUserProjects` has no UI consumer. The debt is not compounding.

Crucially, the instance type is not what protects the console. Admin access passes two independent gates, both failing closed:

| Layer | Requirement | On failure |
| --- | --- | --- |
| `src/proxy.ts` | Clerk membership in an org named `ADMIN` with role `org:admin` | Redirect to `/not-authorized` |
| `convex/authz.ts` | `users.role === "admin"`; new users default to `"customer"` | Query returns empty, mutation throws |

## Open public sign-up

`/signup` is reachable and linked from `<SignIn signUpUrl="/signup" />` even though accounts do nothing for customers — leads arrive through the contact form.

The gates above make this a quota concern rather than an access one, which is why it is being left alone. The failure mode worth recording is narrower and less obvious than privilege escalation: junk sign-ups consume the development instance's 100-user cap and its 100-emails-per-month allowance, and an exhausted email quota could stop the operator's own sign-in emails from sending. The doc notes both the dashboard toggle and the code change that would close it.

## `isClerkUserIdAdmin` on every admin request

`isClerkUserIdAdmin` resolves admin status by fetching organisation memberships from the Clerk Backend API, and `proxy.ts` calls it for every request under `/admin`. Every admin page load and navigation pays a round trip to Clerk before anything renders.

At one operator this sits far inside the development instance's 100 requests per 10 seconds, so it is a latency cost rather than a correctness problem — but it is the first limit real load would reach, and it explains why admin navigation feels slower than the rest of the site. The documented fix is to carry the admin claim in the session token so the check stays at the edge.

## Files

New "Authentication" section in `DEPLOYMENTS.md`, plus pointers to it from the three hot-path locations where the reasoning would otherwise have to be rediscovered: `src/proxy.ts`, `src/utils/auth/ClerkUtils.ts`, and `src/app/signin/[[...sign-in]]/page.tsx`.
