### PR TITLE
Stop serving inventory costs and client addresses to anonymous callers

### DIFF
--- a/convex/inventory.ts
+++ b/convex/inventory.ts
@@ -24,88 +24,6 @@ export const getAllInventory = query({
   },
 });
 
-// Get all inventory with filters
-export const getInventory = query({
-  args: {
-    category: v.optional(v.string()),
-    active: v.optional(v.boolean()),
-    search: v.optional(v.string()),
-  },
-  handler: async (ctx, args) => {
-    let inventoryQuery = ctx.db.query("inventory");
-
-    if (args.active !== undefined) {
-      inventoryQuery = inventoryQuery.filter((q) => q.eq(q.field("active"), args.active));
-    }
-
-    if (args.category) {
-      inventoryQuery = inventoryQuery.filter((q) => q.eq(q.field("category"), args.category));
-    }
-
-    const inventory = await inventoryQuery.collect();
-
-    // Apply search filter if provided
-    let filtered = inventory;
-    if (args.search) {
-      const searchLower = args.search.toLowerCase();
-      filtered = inventory.filter(
-        (item) => item.name.toLowerCase().includes(searchLower) || item.description.toLowerCase().includes(searchLower),
-      );
-    }
-
-    // Sort by oId descending
-    return filtered.sort((a, b) => b.oId - a.oId);
-  },
-});
-
-// Get single inventory item with images
-export const getInventoryItem = query({
-  args: { id: v.id("inventory") },
-  handler: async (ctx, args) => {
-    const item = await ctx.db.get(args.id);
-    if (!item) return null;
-
-    const extraImages = await ctx.db
-      .query("extraImages")
-      .withIndex("by_inventory", (q) => q.eq("inventoryId", args.id))
-      .collect();
-
-    // Sort extra images by display order
-    extraImages.sort((a, b) => (a.displayOrder || 0) - (b.displayOrder || 0));
-
-    return {
-      ...item,
-      extraImages,
-    };
-  },
-});
-
-// Get single inventory item by original ID (oId)
-export const getInventoryItemByOId = query({
-  args: { oId: v.number() },
-  handler: async (ctx, args) => {
-    const item = await ctx.db
-      .query("inventory")
-      .filter((q) => q.eq(q.field("oId"), args.oId))
-      .first();
-
-    if (!item) return null;
-
-    const extraImages = await ctx.db
-      .query("extraImages")
-      .withIndex("by_inventory", (q) => q.eq("inventoryId", item._id))
-      .collect();
-
-    // Sort extra images by display order
-    extraImages.sort((a, b) => (a.displayOrder || 0) - (b.displayOrder || 0));
-
-    return {
-      ...item,
-      extraImages,
-    };
-  },
-});
-
 /**
  * Creates one catalog item and returns the identifier it was given.
  *
@@ -282,53 +200,11 @@ export const deleteInventory = mutation({
   },
 });
 
-/** Derived availability for one item, plus which houses are holding it. */
-export const getInventoryAvailability = query({
-  args: { id: v.id("inventory") },
-  handler: async (ctx, args) => {
-    const item = await ctx.db.get(args.id);
-    if (!item) return null;
-
-    return availabilityForItem(ctx, args.id);
-  },
-});
-
-// Get inventory categories
-export const getInventoryCategories = query({
-  handler: async (ctx) => {
-    const inventory = await ctx.db.query("inventory").collect();
-    const categories = [...new Set(inventory.map((item) => item.category))];
-    return categories.sort();
-  },
-});
-
-// Get adjacent inventory oIds for navigation
-export const getAdjacentInventoryOIds = query({
-  args: { oId: v.number() },
-  handler: async (ctx, args) => {
-    const inventory = await ctx.db.query("inventory").collect();
-
-    // Sort by oId descending (most recent first)
-    const sorted = inventory.sort((a, b) => b.oId - a.oId);
-
-    // Find current index
-    const currentIndex = sorted.findIndex((item) => item.oId === args.oId);
-
-    if (currentIndex === -1) {
-      return { nextOId: null, prevOId: null };
-    }
-
-    // Get adjacent oIds
-    const nextOId = currentIndex > 0 ? sorted[currentIndex - 1].oId : null;
-    const prevOId = currentIndex < sorted.length - 1 ? sorted[currentIndex + 1].oId : null;
-
-    return { nextOId, prevOId };
-  },
-});
-
 // Get most recent inventory oId
 export const getMostRecentOId = query({
   handler: async (ctx) => {
+    if (!(await isAdmin(ctx))) return null;
+
     const inventory = await ctx.db.query("inventory").collect();
 
     if (inventory.length === 0) return null;

--- a/convex/projects.ts
+++ b/convex/projects.ts
@@ -6,6 +6,14 @@ import { openAssignments, syncItemCounter, syncProjectFlag } from "./availabilit
 import { paymentState } from "./payments";
 
 // Get highlighted projects for portfolio
+/**
+ * The homepage portfolio. This is the one project read that is reachable without auth, so it
+ * returns an explicit field list rather than the stored document.
+ *
+ * Spreading the project used to ship `address`, `revenue`, `inventoryRentalCost` and `ownerId`
+ * to anyone who called the deployment URL, which is public because it ships in the client
+ * bundle. The portfolio only ever renders a name and its photos.
+ */
 export const getHighlightedProjects = query({
   handler: async (ctx) => {
     const projects = await ctx.db
@@ -24,8 +32,18 @@ export const getHighlightedProjects = query({
           .collect();
 
         return {
-          ...project,
-          images: images.sort((a, b) => a.displayOrder - b.displayOrder),
+          _id: project._id,
+          name: project.name,
+          images: images
+            .sort((a, b) => a.displayOrder - b.displayOrder)
+            .map((image) => ({
+              _id: image._id,
+              imagePath: image.imagePath,
+              thumbnailPath: image.thumbnailPath,
+              title: image.title,
+              width: image.width,
+              height: image.height,
+            })),
         };
       }),
     );


### PR DESCRIPTION
Closes two paths that served back-office data to unauthenticated callers. Convex functions are callable by anyone holding the deployment URL, and that URL ships in the client bundle, so "no UI calls it" is not a protection.

## Inventory costs, vendors and storage locations

`getInventory` had no auth check and returned complete documents for all 425 rows. It also ignored `active`, so items deliberately hidden from the public catalog came back as well.

| Exposed | Detail |
| --- | --- |
| `cost` | 252 items carry a real purchase price |
| `vendor` | Supplier per item |
| `location` | Physical storage location |
| Hidden items | `active: false` rows returned alongside the rest |

Five sibling queries were equally open and equally unused: `getInventoryItem`, `getInventoryItemByOId`, `getInventoryAvailability`, `getInventoryCategories`, `getAdjacentInventoryOIds`. All six are **removed** rather than gated — every catalog surface moved to `getCatalog` / `getInventoryDetail` / `getInventoryEditor`, which were already correctly gated. Deleting them is a smaller attack surface than protecting code nothing calls.

`getMostRecentOId` is the one open query with a live consumer, so it takes an `isAdmin` check and returns `null` while Clerk hydrates, matching the established pattern for admin reads.

## Client addresses and job revenue

`getHighlightedProjects` is the homepage portfolio and is legitimately public, but it returned `...project` — the whole stored document. That shipped `address`, `revenue`, `inventoryRentalCost` and `ownerId` for the six featured jobs to any anonymous caller.

It now returns an explicit field list: `_id`, `name`, and a projected `images` array carrying only `imagePath`, `thumbnailPath`, `title`, `width`, `height`. That is exactly what `portfolio.tsx` and `PortfolioLightbox.tsx` render, verified by reading both.

## Confirmed against production

Anonymous HTTP `POST /api/query`, no credentials, before and after the Convex deploy:

```
before  inventory:getInventory          → 425 rows, cost/vendor/location present
after   inventory:getInventory          → error

before  projects:getHighlightedProjects → address, revenue, inventoryRentalCost, ownerId
after   projects:getHighlightedProjects → _id, name, images   (6 projects, 6 images each)
```

The portfolio still renders. The four functions that remain reachable without auth are intentional and were each checked: `createSubmission` (the public contact form's only write), `getHomepageImages` and `getHighlightedProjects` (homepage rendering, now projected), and `getOrCreateUser` (Clerk sign-in sync).
