### PR TITLE
Bind the item editor to document ids and stop losing admin work silently

### DIFF
--- a/convex/inventory.ts
+++ b/convex/inventory.ts
@@ -599,13 +599,32 @@ export const setInventoryDimensions = mutation({
  * recent id, and nothing at all about whether the thing was out on a job. Availability belongs here:
  * it is the number that decides whether lowering the count is safe.
  */
-export const getInventoryEditor = query({
+/**
+ * Resolves a catalog number to the immutable document id.
+ *
+ * `oId` doubles as display order, and reordering swaps it between two rows, so it is not a stable
+ * handle on a record. Links that still carry `?id=<oId>` resolve through this once and then hold
+ * the `_id`, which cannot change underneath an open editor.
+ */
+export const getInventoryIdByOId = query({
   args: { oId: v.number() },
+  handler: async (ctx, args) => {
+    if (!(await isAdmin(ctx))) return null;
+    const match = await ctx.db
+      .query("inventory")
+      .filter((q) => q.eq(q.field("oId"), args.oId))
+      .first();
+    return match ? match._id : null;
+  },
+});
+
+export const getInventoryEditor = query({
+  args: { id: v.id("inventory") },
   handler: async (ctx, args) => {
     if (!(await isAdmin(ctx))) return null;
 
     const catalog = await ctx.db.query("inventory").collect();
-    const item = catalog.find((row) => row.oId === args.oId);
+    const item = catalog.find((row) => row._id === args.id);
     if (!item) return null;
 
     const [extraImages, availability] = await Promise.all([
@@ -618,15 +637,15 @@ export const getInventoryEditor = query({
 
     /* Newest first, matching the order the catalog and the old prev/next arrows walked. */
     const ordered = [...catalog].sort((a, b) => b.oId - a.oId);
-    const index = ordered.findIndex((row) => row.oId === args.oId);
+    const index = ordered.findIndex((row) => row._id === args.id);
 
     return {
       ...item,
       extraImages: extraImages.sort((a, b) => (a.displayOrder || 0) - (b.displayOrder || 0)),
       availability,
       attention: attentionReasons(item, availability),
-      newerOId: index > 0 ? ordered[index - 1].oId : null,
-      olderOId: index < ordered.length - 1 ? ordered[index + 1].oId : null,
+      newerId: index > 0 ? ordered[index - 1]._id : null,
+      olderId: index < ordered.length - 1 ? ordered[index + 1]._id : null,
       position: index + 1,
       total: ordered.length,
       /* Existing values, so the editor can offer what is already in use before inventing a new one. */

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "prettier": "prettier --write \"**/*.{js,jsx,json,md,ts,tsx}\"",
-    "sync-users": "tsx scripts/sync-clerk-users.ts",
     "backup": "./scripts/backup-convex.sh prod",
     "backup:dev": "./scripts/backup-convex.sh dev"
   },
@@ -73,7 +72,6 @@
     "typescript": "^5.6.3",
     "vitest": "^4.1.11"
   },
-  "types": "./src/types.d.ts",
   "pnpm": {
     "onlyBuiltDependencies": [
       "@clerk/shared",

--- a/src/app/admin/edit/EditInventoryClient.tsx
+++ b/src/app/admin/edit/EditInventoryClient.tsx
@@ -53,19 +53,23 @@ function toForm(item: EditorItem): InventoryFormState {
     };
 }
 
-export default function EditInventoryClient({ oId }: { oId: number }) {
-    const item = useQuery(api.inventory.getInventoryEditor, { oId }) as EditorItem | null | undefined;
+export default function EditInventoryClient({ id }: { id: Id<'inventory'> }) {
+    const item = useQuery(api.inventory.getInventoryEditor, { id }) as EditorItem | null | undefined;
     const saveItem = useMutation(api.inventory.updateInventoryDetails);
 
     const [form, setForm] = useState<InventoryFormState | null>(null);
     /*
-     * Seeded during render rather than in an effect, keyed on the item. This is a live subscription:
-     * it re-emits on every photo edit, and re-seeding on each of those would discard whatever was
-     * being typed at the time.
+     * Seeded during render rather than in an effect, keyed on the immutable `_id`. This is a live
+     * subscription: it re-emits on every photo edit, and re-seeding on each of those would discard
+     * whatever was being typed at the time.
+     *
+     * The key has to be `_id`, not `oId`. Reordering the catalog swaps `oId` between two rows, so a
+     * subscription keyed on it would quietly hand this editor a different record carrying the same
+     * number, leave the guard satisfied, and save the open draft onto that other item.
      */
-    const [seededFor, setSeededFor] = useState<number | null>(null);
-    if (item && seededFor !== item.oId) {
-        setSeededFor(item.oId);
+    const [seededFor, setSeededFor] = useState<string | null>(null);
+    if (item && seededFor !== item._id) {
+        setSeededFor(item._id);
         setForm(toForm(item));
     }
 
@@ -195,8 +199,8 @@ export default function EditInventoryClient({ oId }: { oId: number }) {
                         <span className="text-body-subtle px-1 text-xs tabular-nums">
                             {item.position} / {item.total}
                         </span>
-                        <NavArrow oId={item.newerOId} label="Newer item" icon={ChevronLeft} />
-                        <NavArrow oId={item.olderOId} label="Older item" icon={ChevronRight} />
+                        <NavArrow id={item.newerId} label="Newer item" icon={ChevronLeft} />
+                        <NavArrow id={item.olderId} label="Older item" icon={ChevronRight} />
                     </div>
                 </div>
             </header>
@@ -230,8 +234,8 @@ export default function EditInventoryClient({ oId }: { oId: number }) {
     );
 }
 
-function NavArrow({ oId, label, icon: Icon }: { oId: number | null; label: string; icon: typeof ChevronLeft }) {
-    if (!oId) {
+function NavArrow({ id, label, icon: Icon }: { id: Id<'inventory'> | null; label: string; icon: typeof ChevronLeft }) {
+    if (!id) {
         return (
             <span aria-hidden="true" className="border-line text-body-subtle grid h-7 w-7 place-items-center rounded border opacity-30">
                 <Icon size={13} />
@@ -241,7 +245,7 @@ function NavArrow({ oId, label, icon: Icon }: { oId: number | null; label: strin
 
     return (
         <Link
-            href={`/admin/edit?id=${oId}`}
+            href={`/admin/edit?item=${id}`}
             aria-label={label}
             className="border-line text-body-muted hover:bg-surface-hover hover:text-body grid h-7 w-7 place-items-center rounded border transition-colors"
         >

--- a/src/app/admin/edit/EditInventoryEntry.tsx
+++ b/src/app/admin/edit/EditInventoryEntry.tsx
@@ -6,25 +6,46 @@ import { useSearchParams } from 'next/navigation';
 import { useQuery } from 'convex/react';
 
 import { api } from '@/convex/_generated/api';
+import type { Id } from '@/convex/_generated/dataModel';
 
 import EditInventoryClient from './EditInventoryClient';
 
 /**
- * Resolves `?id=<oId>` into an item to edit.
+ * Resolves the URL into an item to edit.
  *
- * The id in the URL is the original catalog number, not a Convex id, because that is what every
- * link into this page has carried since the migration. With no id, the most recently added item is
- * the one to land on — that is almost always the one just created.
+ * `?item=<convexId>` is the current form and is what every link in the console now emits. The
+ * document id never changes, so an open editor stays bound to the record it was opened on.
+ *
+ * `?id=<oId>` is the older catalog-number form, kept working for bookmarks. It is resolved to a
+ * document id once and then dropped, because `oId` doubles as display order: reordering the catalog
+ * swaps it between two rows, so it is not a stable handle on a record.
+ *
+ * With neither, the most recently added item is the one to land on — almost always the one just
+ * created.
  */
 function EditInventoryEntryContent() {
     const searchParams = useSearchParams();
+
+    const itemId = searchParams.get('item');
     const raw = searchParams.get('id');
     const parsed = raw ? Number.parseInt(raw, 10) : null;
-    const oId = parsed !== null && Number.isFinite(parsed) ? parsed : null;
+    const legacyOId = parsed !== null && Number.isFinite(parsed) ? parsed : null;
 
-    const mostRecentOId = useQuery(api.inventory.getMostRecentOId, oId === null ? {} : 'skip');
+    const resolvedId = useQuery(api.inventory.getInventoryIdByOId, itemId === null && legacyOId !== null ? { oId: legacyOId } : 'skip');
+    const mostRecentOId = useQuery(api.inventory.getMostRecentOId, itemId === null && legacyOId === null ? {} : 'skip');
+    const fallbackId = useQuery(
+        api.inventory.getInventoryIdByOId,
+        itemId === null && legacyOId === null && typeof mostRecentOId === 'number' ? { oId: mostRecentOId } : 'skip',
+    );
 
-    if (oId !== null) return <EditInventoryClient oId={oId} />;
+    if (itemId !== null) return <EditInventoryClient id={itemId as Id<'inventory'>} />;
+
+    if (legacyOId !== null) {
+        if (resolvedId === undefined) return <p className="text-body-muted p-6 text-sm">Loading item…</p>;
+        if (resolvedId) return <EditInventoryClient id={resolvedId} />;
+        return <p className="text-body-muted p-6 text-sm">That item no longer exists.</p>;
+    }
+
     if (mostRecentOId === undefined) return <p className="text-body-muted p-6 text-sm">Loading item…</p>;
 
     if (mostRecentOId === null) {
@@ -38,7 +59,10 @@ function EditInventoryEntryContent() {
         );
     }
 
-    return <EditInventoryClient oId={mostRecentOId} />;
+    if (fallbackId === undefined) return <p className="text-body-muted p-6 text-sm">Loading item…</p>;
+    if (!fallbackId) return <p className="text-body-muted p-6 text-sm">That item no longer exists.</p>;
+
+    return <EditInventoryClient id={fallbackId} />;
 }
 
 export default function EditInventoryEntry() {

--- a/src/app/admin/edit/inventory.editor.types.ts
+++ b/src/app/admin/edit/inventory.editor.types.ts
@@ -1,3 +1,4 @@
+import type { Id } from '@/convex/_generated/dataModel';
 import type { AttentionReason } from '@/app/admin/inventory/attention/attention.types';
 
 /** Availability for one item, as `availabilityForItem` returns it. */
@@ -53,8 +54,8 @@ export interface EditorItem {
     extraImages: EditorExtraImage[];
     availability: EditorAvailability;
     attention: AttentionReason[];
-    newerOId: number | null;
-    olderOId: number | null;
+    newerId: Id<'inventory'> | null;
+    olderId: Id<'inventory'> | null;
     position: number;
     total: number;
     categories: string[];

--- a/src/app/admin/edit/new/CreateInventoryConvex.tsx
+++ b/src/app/admin/edit/new/CreateInventoryConvex.tsx
@@ -41,7 +41,7 @@ export default function CreateInventoryConvex() {
         setSaving(true);
         setError(null);
         try {
-            const { oId } = await createInventory({
+            const { inventoryId } = await createInventory({
                 active: true,
                 name: name.trim(),
                 cost: 0,
@@ -64,7 +64,7 @@ export default function CreateInventoryConvex() {
             });
 
             revokePreviews(pending);
-            router.push(destination === 'edit' ? `/admin/edit?id=${oId}` : `/admin/inventory?item=${oId}`);
+            router.push(destination === 'edit' ? `/admin/edit?item=${inventoryId}` : `/admin/inventory?item=${inventoryId}`);
         } catch (caught) {
             setError(caught instanceof Error ? caught.message : 'Could not create that item.');
             setSaving(false);

--- a/src/app/admin/inventory/InventoryConvexClient.tsx
+++ b/src/app/admin/inventory/InventoryConvexClient.tsx
@@ -60,8 +60,9 @@ export default function InventoryConvexClient() {
     const { toggle, setQuantity, remove, clear, summary } = useStagingList(items ?? undefined, projectId ?? undefined);
 
     const [showAddOverlay, setShowAddOverlay] = useState(false);
-    const [detailId, setDetailId] = useState<string | null>(null);
-    const [panelOpen, setPanelOpen] = useState(false);
+    /* `?item=` is how the creation flow hands the new item straight to its detail column. */
+    const [detailId, setDetailId] = useState<string | null>(searchParams.get('item'));
+    const [panelOpen, setPanelOpen] = useState(searchParams.get('item') !== null);
     const [lightbox, setLightbox] = useState<{ src: string; alt: string } | null>(null);
     const [problems, setProblems] = useState<LineProblem[]>([]);
     const [committing, setCommitting] = useState(false);
@@ -88,9 +89,13 @@ export default function InventoryConvexClient() {
     };
 
     const handleProjectChange = (nextProjectId: string | null) => {
+        /*
+         * No `clear()` here. Each house's pending list is persisted under its own key and restored
+         * by `useStagingList`, so switching away and back is how a half-built list survives a trip
+         * to another manifest. Clearing on switch wrote an empty draft over the list belonging to
+         * the house being left, because `clear` closes over the previous `projectId`.
+         */
         setProjectId(nextProjectId);
-        /* The pending list belongs to the house it was built for. */
-        clear();
         setProblems([]);
         setFlash(null);
         setCommitError(null);

--- a/src/app/admin/inventory/ItemDetailPanel.tsx
+++ b/src/app/admin/inventory/ItemDetailPanel.tsx
@@ -263,7 +263,7 @@ export default function ItemDetailPanel({
                             </div>
                         </div>
                         <Link
-                            href={`/admin/edit?id=${detail.oId}`}
+                            href={`/admin/edit?item=${detail._id}`}
                             className="bg-gold-400 text-body-inverse hover:bg-gold-300 inline-flex w-full items-center justify-center gap-2 rounded-md px-4 py-2.5 text-sm font-bold transition-colors"
                         >
                             <Pencil size={15} aria-hidden="true" /> Edit this item

--- a/src/app/admin/inventory/ProjectWorkspacePanel.tsx
+++ b/src/app/admin/inventory/ProjectWorkspacePanel.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState } from 'react';
 import Link from 'next/link';
 import { useMutation, useQuery } from 'convex/react';
 import { ExternalLink, Loader2, PackageOpen, Trash2, Undo2 } from 'lucide-react';
@@ -48,6 +49,21 @@ export default function ProjectWorkspacePanel({
         projectId: project._id as Id<'projects'>,
     });
     const checkIn = useMutation(api.assignments.checkInAssignments);
+    const [checkInError, setCheckInError] = useState<string | null>(null);
+    const [checkingIn, setCheckingIn] = useState<string | null>(null);
+
+    /* Check-in writes immediately from a row; a rejection here used to leave the row unchanged and silent. */
+    const runCheckIn = async (assignmentId: Id<'projectInventory'>) => {
+        setCheckInError(null);
+        setCheckingIn(assignmentId);
+        try {
+            await checkIn({ assignmentIds: [assignmentId] });
+        } catch (caught) {
+            setCheckInError(caught instanceof Error ? caught.message : 'Could not check that item back in.');
+        } finally {
+            setCheckingIn(null);
+        }
+    };
 
     const problemsById = new Map(problems.map((problem) => [problem.inventoryId, problem] as const));
     const touched = [...summary.adding, ...summary.changing, ...summary.removing];
@@ -135,6 +151,11 @@ export default function ProjectWorkspacePanel({
                         </div>
                     ) : (
                         <>
+                            {checkInError && (
+                                <p role="alert" className="text-danger border-line border-b px-4 py-2 text-xs font-semibold">
+                                    {checkInError}
+                                </p>
+                            )}
                             <ul className="divide-line divide-y">
                                 {onSite.map((line) => (
                                     <AssignmentRow
@@ -147,9 +168,10 @@ export default function ProjectWorkspacePanel({
                                         action={
                                             <button
                                                 type="button"
-                                                onClick={() => checkIn({ assignmentIds: [line._id as Id<'projectInventory'>] })}
+                                                onClick={() => void runCheckIn(line._id as Id<'projectInventory'>)}
+                                                disabled={checkingIn === line._id}
                                                 aria-label={`Check ${line.name} back in`}
-                                                className="border-line-strong text-body-muted hover:bg-surface-hover hover:text-body inline-flex items-center gap-1.5 rounded-md border px-2.5 py-2 text-xs font-bold transition-colors"
+                                                className="border-line-strong text-body-muted hover:bg-surface-hover hover:text-body inline-flex items-center gap-1.5 rounded-md border px-2.5 py-2 text-xs font-bold transition-colors disabled:opacity-50"
                                             >
                                                 <Undo2 size={13} aria-hidden="true" /> In
                                             </button>

--- a/src/app/admin/inventory/attention/AttentionFixRow.tsx
+++ b/src/app/admin/inventory/attention/AttentionFixRow.tsx
@@ -225,7 +225,7 @@ export default function AttentionFixRow({ item, onFixed }: { item: AttentionItem
             </span>
 
             <Link
-                href={`/admin/edit?id=${item.oId}`}
+                href={`/admin/edit?item=${item._id}`}
                 className="border-line text-body-muted hover:bg-surface-hover hover:text-body inline-flex shrink-0 items-center gap-1.5 self-start rounded-md border px-3 py-2 text-xs font-bold transition-colors"
             >
                 <Pencil size={13} aria-hidden="true" /> Full editor

--- a/src/app/admin/manage/homepage/HomepageManageClient.tsx
+++ b/src/app/admin/manage/homepage/HomepageManageClient.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useRef, useMemo } from 'react';
+import { useDialogFocus } from '@/hooks/useDialogFocus';
 import { useQuery, useMutation } from 'convex/react';
 import { api } from '@/convex/_generated/api';
 import { Id, Doc } from '@/convex/_generated/dataModel';
@@ -268,6 +269,7 @@ export default function HomepageManageClient() {
     const [selectedProject, setSelectedProject] = useState(0);
     const [selectedProjectImages, setSelectedProjectImages] = useState<Set<string>>(new Set());
     const [editingCaptionId, setEditingCaptionId] = useState<string | null>(null);
+    const captionDialogRef = useDialogFocus<HTMLDivElement>(editingCaptionId !== null, () => setEditingCaptionId(null));
     const [captionInput, setCaptionInput] = useState('');
     const [draggedIndex, setDraggedIndex] = useState<number | null>(null);
     const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
@@ -411,6 +413,9 @@ export default function HomepageManageClient() {
                 projectImageIds: Array.from(selectedProjectImages) as Id<'projectImages'>[],
             });
             setSelectedProjectImages(new Set());
+        } catch (caught) {
+            /* Without this the rejection only stopped the spinner and became an unhandled promise. */
+            setError(caught instanceof Error ? caught.message : 'Could not add those photos to the homepage.');
         } finally {
             setIsAdding(false);
         }
@@ -450,6 +455,8 @@ export default function HomepageManageClient() {
             });
             setPendingUpload(null);
             setUploadCaption('');
+        } catch (caught) {
+            setError(caught instanceof Error ? caught.message : 'Could not add that image to the homepage.');
         } finally {
             setIsAdding(false);
         }
@@ -537,11 +544,18 @@ export default function HomepageManageClient() {
                 {/* ─── Caption Edit Modal ───────────────────────────────────── */}
                 {editingCaptionId && (
                     <div
+                        ref={captionDialogRef}
+                        role="dialog"
+                        aria-modal="true"
+                        aria-labelledby="caption-dialog-title"
+                        tabIndex={-1}
                         className="bg-surface/80 fixed inset-0 z-50 flex items-center justify-center"
                         onClick={() => setEditingCaptionId(null)}
                     >
                         <div onClick={(e) => e.stopPropagation()} className="bg-surface-raised w-full max-w-md rounded-xl p-6 shadow-2xl">
-                            <h3 className="text-body mb-4 text-lg font-semibold">Edit Caption</h3>
+                            <h3 id="caption-dialog-title" className="text-body mb-4 text-lg font-semibold">
+                                Edit Caption
+                            </h3>
                             <input
                                 type="text"
                                 value={captionInput}
@@ -669,15 +683,23 @@ export default function HomepageManageClient() {
                                                 const alreadyAdded = image.alreadyOnHomepage;
 
                                                 return (
-                                                    <div
+                                                    <button
                                                         key={image._id}
-                                                        onClick={() => !alreadyAdded && toggleProjectImageSelection(image._id.toString())}
-                                                        className={`relative cursor-pointer overflow-hidden rounded-lg transition-all duration-200 ${
+                                                        type="button"
+                                                        onClick={() => toggleProjectImageSelection(image._id.toString())}
+                                                        disabled={alreadyAdded}
+                                                        aria-pressed={isSelected}
+                                                        aria-label={
+                                                            alreadyAdded
+                                                                ? `${image.title ?? 'Project photo'} is already on the homepage`
+                                                                : `${image.title ?? 'Project photo'}${isSelected ? ', selected' : ''}`
+                                                        }
+                                                        className={`focus-visible:ring-gold-400 relative block w-full overflow-hidden rounded-lg transition-all duration-200 focus-visible:ring-2 focus-visible:outline-none ${
                                                             alreadyAdded
                                                                 ? 'cursor-not-allowed opacity-40'
                                                                 : isSelected
-                                                                  ? 'ring-primary scale-[0.97] ring-2'
-                                                                  : 'hover:ring-2 hover:ring-stone-500'
+                                                                  ? 'ring-gold-400 scale-[0.97] cursor-pointer ring-2'
+                                                                  : 'cursor-pointer hover:ring-2 hover:ring-stone-500'
                                                         }`}
                                                     >
                                                         <Image
@@ -685,7 +707,8 @@ export default function HomepageManageClient() {
                                                             width={image.thumbnailWidth || image.width}
                                                             height={image.thumbnailHeight || image.height}
                                                             className="aspect-square w-full object-cover"
-                                                            alt="Project image"
+                                                            /* The button carries the name; a second one here would double it in the a11y tree. */
+                                                            alt=""
                                                             sizes="(max-width: 640px) 50vw, (max-width: 1024px) 25vw, 20vw"
                                                         />
 
@@ -704,7 +727,7 @@ export default function HomepageManageClient() {
                                                                 </span>
                                                             </div>
                                                         )}
-                                                    </div>
+                                                    </button>
                                                 );
                                             })}
                                         </div>

--- a/src/app/admin/projects/AdminProjectsClient.tsx
+++ b/src/app/admin/projects/AdminProjectsClient.tsx
@@ -49,6 +49,17 @@ export default function AdminProjectsClient() {
     const [payment, setPayment] = useState<MoneyFilter>('all');
     const [panelOpen, setPanelOpen] = useState(false);
     const [payingId, setPayingId] = useState<string | null>(null);
+    const [error, setError] = useState<string | null>(null);
+
+    /* Reorder and highlight both write straight to Convex; without this a rejection was invisible. */
+    const runOrFail = async (action: Promise<unknown>, message: string) => {
+        setError(null);
+        try {
+            await action;
+        } catch (caught) {
+            setError(caught instanceof Error ? caught.message : message);
+        }
+    };
 
     const filtered = useMemo(() => {
         const term = search.trim().toLowerCase();
@@ -91,8 +102,15 @@ export default function AdminProjectsClient() {
         const args = { projectId: project._id as Id<'projects'> };
 
         /* The ends wrap, which is how a project gets to the front of the portfolio in one click. */
-        if (direction === -1) void (index === 0 ? moveToLast(args) : moveUp(args));
-        else void (index === all.length - 1 ? moveToFirst(args) : moveDown(args));
+        const action =
+            direction === -1
+                ? index === 0
+                    ? moveToLast(args)
+                    : moveUp(args)
+                : index === all.length - 1
+                  ? moveToFirst(args)
+                  : moveDown(args);
+        void runOrFail(action, 'Could not reorder that project.');
     };
 
     const panelBody = selected ? (
@@ -221,6 +239,11 @@ export default function AdminProjectsClient() {
                         </div>
                     ) : (
                         <>
+                            {error && (
+                                <p role="alert" className="text-danger border-line border-b px-4 py-2 text-xs font-semibold">
+                                    {error}
+                                </p>
+                            )}
                             {filtering && (
                                 <p className="border-line text-body-subtle flex items-center gap-1.5 border-b px-4 py-2 text-xs">
                                     <SlidersHorizontal size={11} aria-hidden="true" />
@@ -237,7 +260,12 @@ export default function AdminProjectsClient() {
                                         reorderable={!filtering}
                                         onSelect={() => select(project._id)}
                                         onMove={(direction) => handleMove(project, direction)}
-                                        onToggleHighlight={() => void toggleHighlight({ projectId: project._id as Id<'projects'> })}
+                                        onToggleHighlight={() =>
+                                            void runOrFail(
+                                                toggleHighlight({ projectId: project._id as Id<'projects'> }),
+                                                'Could not change what is highlighted.',
+                                            )
+                                        }
                                     />
                                 ))}
                             </ul>

--- a/src/app/admin/projects/[id]/edit/EditProjectClient.tsx
+++ b/src/app/admin/projects/[id]/edit/EditProjectClient.tsx
@@ -47,6 +47,36 @@ const STATUS_TONES: Record<ProjectStatus, string> = {
     cancelled: 'border-danger/40 bg-danger-soft text-danger',
 };
 
+/**
+ * The single projection from a stored project to form state. Seeding and dirty detection both go
+ * through this so a field cannot be editable but excluded from the comparison.
+ */
+function toForm(project: {
+    name?: string;
+    status?: string;
+    address?: string;
+    startDate?: number | null;
+    endDate?: number | null;
+    revenue?: number | null;
+    notes?: string;
+    highlighted?: boolean;
+}): ProjectFormState {
+    return {
+        name: project.name || '',
+        /*
+         * This used to force every non-draft project back to 'draft' when the form loaded, so
+         * opening a completed job and saving it silently reopened it.
+         */
+        status: (project.status as ProjectStatus) ?? 'draft',
+        address: project.address || '',
+        startDate: project.startDate ? new Date(project.startDate).toISOString().split('T')[0] : '',
+        endDate: project.endDate ? new Date(project.endDate).toISOString().split('T')[0] : '',
+        revenue: project.revenue ? project.revenue.toString() : '',
+        notes: project.notes || '',
+        highlighted: project.highlighted || false,
+    };
+}
+
 export default function EditProjectClient({ projectId }: { projectId: string }) {
     const { user, isLoaded } = useUser();
 
@@ -84,32 +114,16 @@ export default function EditProjectClient({ projectId }: { projectId: string }) 
     const [seededFor, setSeededFor] = useState<string | null>(null);
     if (project && seededFor !== project._id) {
         setSeededFor(project._id);
-        setFormData({
-            name: project.name || '',
-            /*
-             * This used to force every non-draft project back to 'draft' when the form loaded, so
-             * opening a completed job and saving it silently reopened it.
-             */
-            status: (project.status as ProjectStatus) ?? 'draft',
-            address: project.address || '',
-            startDate: project.startDate ? new Date(project.startDate).toISOString().split('T')[0] : '',
-            endDate: project.endDate ? new Date(project.endDate).toISOString().split('T')[0] : '',
-            revenue: project.revenue ? project.revenue.toString() : '',
-            notes: project.notes || '',
-            highlighted: project.highlighted || false,
-        });
+        setFormData(toForm(project));
     }
 
-    /* The form is dirty whenever what is on screen differs from what the last query returned. */
-    const dirty = Boolean(
-        project &&
-        (formData.name !== (project.name || '') ||
-            formData.status !== ((project.status as ProjectStatus) ?? 'draft') ||
-            formData.address !== (project.address || '') ||
-            formData.revenue !== (project.revenue ? project.revenue.toString() : '') ||
-            formData.notes !== (project.notes || '') ||
-            formData.highlighted !== (project.highlighted || false)),
-    );
+    /*
+     * Dirty is a whole-form comparison against the same projection used to seed it. Listing the
+     * fields again by hand is what let start and end dates drift out: they were editable but absent
+     * from the comparison, so a date-only change looked clean and the unsaved-changes guard stayed
+     * off while the tab closed.
+     */
+    const dirty = Boolean(project && JSON.stringify(formData) !== JSON.stringify(toForm(project)));
     useUnsavedChangesWarning(dirty);
 
     const save = async (checkInAssignmentIds?: string[]) => {

--- a/src/components/AddInventoryOverlay.tsx
+++ b/src/components/AddInventoryOverlay.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useCallback } from 'react';
+import { useDialogFocus } from '@/hooks/useDialogFocus';
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 import { useMutation } from 'convex/react';
@@ -13,7 +14,7 @@ import InputSelect from '@/components/inputs/InputSelect';
 
 interface AddInventoryOverlayProps {
     onClose: () => void;
-    onSuccess?: (oId: number) => void;
+    onSuccess?: (inventoryId: string) => void;
     defaultAction?: 'edit' | 'view' | 'stay';
 }
 
@@ -109,7 +110,7 @@ const AddInventoryOverlay: React.FC<AddInventoryOverlayProps> = ({ onClose, onSu
 
         try {
             /* The identifier comes back from the server; two of these open at once used to collide. */
-            const { oId } = await createInventory({
+            const { inventoryId } = await createInventory({
                 active: true,
                 name: title,
                 cost: cost,
@@ -133,7 +134,7 @@ const AddInventoryOverlay: React.FC<AddInventoryOverlayProps> = ({ onClose, onSu
             setStatusMessage({ type: 'success', message: 'Inventory created successfully!' });
 
             // Call onSuccess callback if provided
-            onSuccess?.(oId);
+            onSuccess?.(inventoryId);
 
             // Close overlay after short delay for success message
             setTimeout(() => {
@@ -142,10 +143,10 @@ const AddInventoryOverlay: React.FC<AddInventoryOverlayProps> = ({ onClose, onSu
                 // Navigate if requested
                 switch (action) {
                     case 'edit':
-                        router.push(`/admin/edit?id=${oId}`);
+                        router.push(`/admin/edit?item=${inventoryId}`);
                         break;
                     case 'view':
-                        router.push(`/admin/inventory?item=${oId}`);
+                        router.push(`/admin/inventory?item=${inventoryId}`);
                         break;
                     case 'stay':
                         // Just refresh the current page
@@ -164,23 +165,36 @@ const AddInventoryOverlay: React.FC<AddInventoryOverlayProps> = ({ onClose, onSu
         }
     };
 
+    /* Open for as long as it is mounted; the parent unmounts it to close. */
+    const dialogRef = useDialogFocus<HTMLDivElement>(true, onClose);
+
     const isFormValid = imageUrl !== 'Not yet uploaded' && title !== 'Not yet uploaded' && !isSubmitting;
 
     return (
         <>
-            <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/75">
+            <div
+                ref={dialogRef}
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby="add-inventory-title"
+                tabIndex={-1}
+                className="fixed inset-0 z-50 flex items-center justify-center bg-black/75"
+            >
                 <div className="bg-surface relative mx-4 max-h-[90vh] w-full max-w-3xl overflow-hidden rounded-lg shadow-2xl">
                     {/* Header */}
                     <div className="bg-surface-raised border-line flex items-center justify-between border-b p-6">
-                        <h2 className="gradient-secondary-main-text text-2xl font-bold">Create New Inventory</h2>
+                        <h2 id="add-inventory-title" className="gradient-secondary-main-text text-2xl font-bold">
+                            Create New Inventory
+                        </h2>
                         <button
                             onClick={onClose}
                             disabled={isSubmitting}
+                            aria-label="Close"
                             className="bg-surface-overlay hover:bg-surface-hover text-body-muted hover:text-body rounded-full p-2 transition-colors disabled:opacity-50"
                             data-tooltip-id="close-btn"
                             data-tooltip-content="Close"
                         >
-                            <X size={24} />
+                            <X size={24} aria-hidden="true" />
                         </button>
                     </div>
 

--- a/src/components/admin/AdminShell.tsx
+++ b/src/components/admin/AdminShell.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, type ReactNode } from 'react';
+import { useDialogFocus } from '@/hooks/useDialogFocus';
 import Image from 'next/image';
 import Link from 'next/link';
 import { ExternalLink, Menu, X } from 'lucide-react';
@@ -42,6 +43,11 @@ function RailContents() {
 
 export default function AdminShell({ title, children }: AdminShellProps) {
     const [menuOpen, setMenuOpen] = useState(false);
+    /*
+     * The rail renders before the header in DOM order, so opening it and pressing Tab used to walk
+     * forward past it into the page behind and skip every admin link. It is a modal dialog now.
+     */
+    const menuRef = useDialogFocus<HTMLDivElement>(menuOpen, () => setMenuOpen(false));
 
     return (
         <div className="bg-ink text-body grid h-[100dvh] w-full grid-cols-1 overflow-hidden lg:grid-cols-[260px_minmax(0,1fr)]">
@@ -50,7 +56,14 @@ export default function AdminShell({ title, children }: AdminShellProps) {
             </aside>
 
             {menuOpen && (
-                <div className="fixed inset-0 z-50 lg:hidden">
+                <div
+                    ref={menuRef}
+                    role="dialog"
+                    aria-modal="true"
+                    aria-label="Admin menu"
+                    tabIndex={-1}
+                    className="fixed inset-0 z-50 lg:hidden"
+                >
                     <button
                         type="button"
                         aria-label="Close menu"


### PR DESCRIPTION
Closes a set of admin bugs that quietly destroy work: the item editor could save your draft onto a different record, switching houses in the catalog wiped the pull list you were building, a project edit that only changed a date read as clean, and several mutations failed with no visible sign.

## The editor was addressed by a number that moves

The catalog number `oId` doubles as display order. Reordering swaps it between two rows, so an `oId` is a handle that can come to mean a different record.

The item editor subscribed by `oId` and guarded its draft seeding on `item.oId`. Reorder while an editor is open and the subscription hands it the neighbouring row, now carrying the same number; the guard sees no change and leaves the old draft in place. Save writes those fields to the neighbour's `_id`.

The editor now takes `?item=<documentId>`. `?id=<oId>` still resolves for existing bookmarks, through a one-time lookup, and the subscription and seed guard key on `_id` from then on. Prev/next carries document ids, as do the links from the catalog detail column, the attention list, and both creation surfaces.

| Route | Before | After |
| --- | --- | --- |
| Item editor | `?id=<oId>` | `?item=<documentId>`, legacy `?id` resolved once |
| Prev / next | `newerOId` / `olderOId` | `newerId` / `olderId` |
| Create → edit | `?id=<oId>` | `?item=<documentId>` |
| Create → catalog | ignored the parameter | opens the new item's detail column |

## Switching houses discarded the pull list

Drafts are stored per project, but `handleProjectChange` called `clear()`, which closes over the *previous* `projectId` and wrote an empty draft over that key. Building a list for one house and glancing at another lost the first list.

Nothing is cleared on switch now; the hook restores each house's list, which is what the per-project storage was for. Commit and the explicit Clear action still clear, which is the only place clearing was intended.

## A date-only project edit read as clean

`EditProjectClient` built its dirty flag from a hand-written field list that omitted `startDate` and `endDate`. Change a date, close the tab, and the unsaved-changes guard stayed silent. Seeding and dirty detection now share one `toForm` projection, so the two cannot drift apart again.

## Failures that were invisible

Project reorder and highlight, the catalog's immediate check-in, and both homepage add flows now surface errors. The homepage handlers used `try`/`finally` with no `catch`, so a rejection became an unhandled promise and the spinner simply stopped. Check-in also gains a busy guard so it cannot be fired twice.

## Keyboard and screen reader

The mobile admin rail renders before the header in DOM order, so opening it and pressing Tab walked straight past it and skipped every admin link. It is a labelled modal dialog with a focus trap now, closing on Escape.

Homepage project photos were clickable `div`s, leaving keyboard users only Select All. They are `button`s with `aria-pressed` and a focus ring, and the image `alt` is dropped so the name is not announced twice. The create-inventory and caption overlays gain dialog roles, labels, focus traps and Escape.

## Also

Drops two `package.json` entries pointing at files that do not exist: the `sync-users` script and a `types` field.
