### PR TITLE
Stop opting the entire site out of server rendering

### DIFF
--- a/src/app/admin/edit/page.tsx
+++ b/src/app/admin/edit/page.tsx
@@ -1,3 +1,5 @@
+import { Suspense } from 'react';
+
 import { adminMetadata } from '@/app/admin/admin.metadata';
 import AdminShell from '@/components/admin/AdminShell';
 
@@ -8,7 +10,9 @@ export const metadata = adminMetadata('Edit item', 'Edit a piece of Capital City
 export default function EditInventoryPage() {
     return (
         <AdminShell title="Edit item">
-            <EditInventoryEntry />
+            <Suspense>
+                <EditInventoryEntry />
+            </Suspense>
         </AdminShell>
     );
 }

--- a/src/app/admin/inventory/page.tsx
+++ b/src/app/admin/inventory/page.tsx
@@ -1,3 +1,5 @@
+import { Suspense } from 'react';
+
 import { adminMetadata } from '@/app/admin/admin.metadata';
 import AdminShell from '@/components/admin/AdminShell';
 
@@ -8,7 +10,9 @@ export const metadata = adminMetadata('Inventory', 'Manage the Capital City Stag
 export default function InventoryPage() {
     return (
         <AdminShell title="Inventory">
-            <InventoryConvexClient />
+            <Suspense>
+                <InventoryConvexClient />
+            </Suspense>
         </AdminShell>
     );
 }

--- a/src/app/admin/projects/page.tsx
+++ b/src/app/admin/projects/page.tsx
@@ -1,3 +1,5 @@
+import { Suspense } from 'react';
+
 import { adminMetadata } from '@/app/admin/admin.metadata';
 import AdminShell from '@/components/admin/AdminShell';
 
@@ -8,7 +10,9 @@ export const metadata = adminMetadata('Projects', 'Manage staging projects for C
 export default function AdminProjectsPage() {
     return (
         <AdminShell title="Projects">
-            <AdminProjectsClient />
+            <Suspense>
+                <AdminProjectsClient />
+            </Suspense>
         </AdminShell>
     );
 }

--- a/src/components/ConvexClientProvider.tsx
+++ b/src/components/ConvexClientProvider.tsx
@@ -2,13 +2,20 @@
 
 import { ReactNode } from 'react';
 import { ConvexReactClient } from 'convex/react';
-import dynamic from 'next/dynamic';
+import { ConvexProviderWithClerk } from 'convex/react-clerk';
 import { useAuth } from '@clerk/nextjs';
 
 const convex = new ConvexReactClient(process.env.NEXT_PUBLIC_CONVEX_URL!);
 
-// Dynamic import to prevent SSR issues
-const ConvexProviderWithClerk = dynamic(() => import('convex/react-clerk').then((mod) => mod.ConvexProviderWithClerk), { ssr: false });
+/**
+ * `ConvexProviderWithClerk` used to be a `dynamic(..., { ssr: false })` import, described as
+ * preventing SSR issues. Because this provider wraps every route, that one flag opted the whole
+ * application out of server rendering: each page shipped an empty shell with
+ * BAILOUT_TO_CLIENT_SIDE_RENDERING and no copy, headings or links in the HTML.
+ *
+ * The provider server-renders correctly on its own. What it was masking is that several admin
+ * clients call `useSearchParams` outside a Suspense boundary; those pages now wrap it explicitly.
+ */
 
 export function ConvexClientProvider({ children }: { children: ReactNode }) {
     return (


### PR DESCRIPTION
Every page on the site was serving an empty shell. The HTML contained the head, the skip link, and nothing else — no headings, no copy, no links, just a `BAILOUT_TO_CLIENT_SIDE_RENDERING` marker where the page should be. Content only appeared after JavaScript ran.

This was not in either audit report. I found it while checking the previous change on the live site, and it outweighs everything else that pass covered.

## One flag, whole application

`ConvexClientProvider` imported `ConvexProviderWithClerk` through `dynamic(..., { ssr: false })`, commented as preventing SSR issues. That provider wraps every route from the root layout, so the flag did not opt one component out of server rendering — it opted out the entire application.

```
- const ConvexProviderWithClerk = dynamic(() => import('convex/react-clerk')..., { ssr: false });
+ import { ConvexProviderWithClerk } from 'convex/react-clerk';
```

## Why nothing caught it

Metadata, canonicals, OpenGraph and JSON-LD all live in `<head>` and rendered correctly throughout, so every metadata check passed. Lighthouse scored 100 on SEO. Any browser-based inspection sees the hydrated DOM, which was complete. Only the raw HTTP response shows the gap, and the site otherwise looks and behaves normally.

## What the flag was hiding

`/admin/inventory`, `/admin/edit` and `/admin/projects` call `useSearchParams` outside a Suspense boundary. With the whole tree bailing to the client, that never surfaced. Each page now wraps its client component in `<Suspense>`, which is the boundary Next asks for and keeps the surrounding page static.

## Verified against a production build served locally

| Check | Result |
| --- | --- |
| Prerendered location page | 37 KB empty shell → 51 KB of real markup |
| `<main>` and content in contact / article / location / service HTML | present |
| Console errors across homepage, contact, location, article, sign-in | none |
| Live Convex data after hydration | portfolio renders its 6 images |
| Skip link: Tab, Enter, Tab | lands inside `<main>`, not the navbar logo |
| Admin gating | `/admin/inventory` still redirects to `/signin` |
| Hero slides mounted | 2, down from 9 |
| Article outline | H1 followed by H2s |
| Article JSON-LD | graph resolves publisher, carries image and `datePublished` |

The navbar remains inside its own Suspense boundary, so it is still client-rendered by design. The footer carries the same internal links and is in the HTML.
