### PR TITLE
Server-render the contact quote form

### DIFF
--- a/src/app/contact/contact_form.tsx
+++ b/src/app/contact/contact_form.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useRef } from 'react';
 
 import { z } from 'zod';
 import { motion, AnimatePresence } from 'framer-motion';
@@ -168,7 +168,6 @@ const ContactForm = () => {
     const createSubmission = useMutation(api.contactSubmissions.createSubmission);
     /* Survives a retry so one enquiry cannot become two rows in the inbox. */
     const submissionIdRef = useRef<Id<'contactSubmissions'> | null>(null);
-    const [mounted, setMounted] = useState(false);
     const [formData, setFormData] = useState<FormData>({
         name: '',
         email: '',
@@ -189,10 +188,6 @@ const ContactForm = () => {
     const [submitMessage, setSubmitMessage] = useState<{ type: 'success' | 'error'; message: string } | null>(null);
     const [showQuote] = useState(true);
     const [isSubmitting, setIsSubmitting] = useState(false);
-
-    useEffect(() => {
-        setMounted(true);
-    }, []);
 
     const handleChange = (field: keyof FormData, value: any) => {
         trackOnce('quote_started', { placement: 'contact_page' });
@@ -322,10 +317,6 @@ const ContactForm = () => {
             setIsSubmitting(false);
         }
     };
-
-    if (!mounted) {
-        return null;
-    }
 
     return (
         <div className="w-full space-y-8">


### PR DESCRIPTION
Follow-on to #23. With the application server-rendering again, `/contact` was the one page whose main content was still absent from the HTML — and it is the page the business depends on.

`ContactForm` returned `null` until a mount effect ran:

```
- const [mounted, setMounted] = useState(false);
- useEffect(() => { setMounted(true); }, []);
- if (!mounted) return null;
```

The server sent nothing, and the first client paint showed nothing where the form belongs. While the whole app was opted out of server rendering this changed little. It is now the difference between a crawler seeing the quote form and seeing an empty section.

Nothing in the form needs to wait for mount. Every field is controlled from initial state that is identical on the server and the client, so the gate was guarding against a mismatch that does not exist.

Verified on a production build served locally:

- No console errors on load
- Both staging-type radios and both live regions present in the server HTML
- Selecting "Occupied Home" with a real click updates the checked state and the visible styling
