### PR TITLE
Collapse the two item-creation surfaces into one, and fix the Recently added sort

### DIFF
--- a/convex/assignments.ts
+++ b/convex/assignments.ts
@@ -269,6 +269,7 @@ export const getPickerData = query({
         return {
           _id: item._id,
           oId: item.oId,
+          createdAt: item.createdAt,
           name: item.name,
           category: item.category,
           price: item.price,

--- a/convex/inventory.ts
+++ b/convex/inventory.ts
@@ -503,6 +503,7 @@ export const getCatalog = query({
         return {
           _id: item._id,
           oId: item.oId,
+          createdAt: item.createdAt,
           name: item.name,
           category: item.category,
           location: item.location,

--- a/src/app/admin/edit/EditInventoryClient.tsx
+++ b/src/app/admin/edit/EditInventoryClient.tsx
@@ -229,7 +229,7 @@ export default function EditInventoryClient({ id }: { id: Id<'inventory'> }) {
                 <InventoryStatusPanel item={item} />
             </section>
 
-            {addingNew && <AddInventoryOverlay onClose={() => setAddingNew(false)} onSuccess={() => setAddingNew(false)} />}
+            {addingNew && <AddInventoryOverlay onClose={() => setAddingNew(false)} />}
         </div>
     );
 }

--- a/src/app/admin/edit/new/CreateInventoryConvex.tsx
+++ b/src/app/admin/edit/new/CreateInventoryConvex.tsx
@@ -1,145 +1,27 @@
 'use client';
 
-import { useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { useMutation } from 'convex/react';
-import { Loader2 } from 'lucide-react';
 
-import { api } from '@/convex/_generated/api';
 import { AdminHeading, AdminPanel } from '@/components/admin/AdminPrimitives';
-import PendingPhotoTray, { pendingSettled, readyPending, revokePreviews } from '@/components/admin/images/PendingPhotoTray';
-import type { PendingImage } from '@/components/admin/images/images.types';
-
-/**
- * Adding one piece of furniture to the catalog.
- *
- * Deliberately short: a photo and a name is enough to have something to find, and everything that
- * takes judgement — price, stock, measurements, category — belongs on the editor this hands off to.
- * The identifier is allocated by the server, so two of these open at once cannot collide.
- */
-
-const FIELD =
-    'border-line bg-surface text-body placeholder:text-body-subtle focus-visible:border-gold-300 w-full rounded-md border px-3 py-2.5 text-sm outline-none transition-colors';
+import CreateInventoryFields from '@/components/admin/inventory/CreateInventoryFields';
 
 export default function CreateInventoryConvex() {
     const router = useRouter();
-    const createInventory = useMutation(api.inventory.createInventory);
-
-    const [pending, setPending] = useState<PendingImage[]>([]);
-    const [name, setName] = useState('');
-    const [saving, setSaving] = useState(false);
-    const [error, setError] = useState<string | null>(null);
-
-    const photo = readyPending(pending)[0];
-    const settled = pendingSettled(pending);
-    const canSubmit = Boolean(photo) && name.trim().length > 0 && settled && !saving;
-    const smallEdge = photo ? Math.min(photo.width ?? 0, photo.height ?? 0) : 0;
-
-    const create = async (destination: 'edit' | 'view') => {
-        if (!photo || !canSubmit) return;
-
-        setSaving(true);
-        setError(null);
-        try {
-            const { inventoryId } = await createInventory({
-                active: true,
-                name: name.trim(),
-                cost: 0,
-                price: 0,
-                vendor: '',
-                category: '',
-                description: '',
-                /* One unit until she says otherwise; zero would read as out of stock everywhere. */
-                count: 1,
-                location: '',
-                realWidth: 0,
-                realHeight: 0,
-                realDepth: 0,
-                imagePath: photo.imagePath as string,
-                width: photo.width as number,
-                height: photo.height as number,
-                smallImagePath: photo.thumbnailPath ?? (photo.imagePath as string),
-                smallWidth: photo.thumbnailWidth ?? (photo.width as number),
-                smallHeight: photo.thumbnailHeight ?? (photo.height as number),
-            });
-
-            revokePreviews(pending);
-            router.push(destination === 'edit' ? `/admin/edit?item=${inventoryId}` : `/admin/inventory?item=${inventoryId}`);
-        } catch (caught) {
-            setError(caught instanceof Error ? caught.message : 'Could not create that item.');
-            setSaving(false);
-        }
-    };
 
     return (
         <div className="flex flex-col gap-5 p-5 sm:p-8">
             <AdminHeading eyebrow="Catalog" title="New item" />
 
-            <div className="grid grid-cols-1 gap-5 xl:grid-cols-[3fr_2fr]">
-                <AdminPanel eyebrow="Photo" title="Main photo">
-                    <div className="p-4">
-                        <PendingPhotoTray
-                            pending={pending}
-                            onPendingChange={(update) => setPending(update)}
-                            onFilesChosen={() => setError(null)}
-                            disabled={saving}
-                        />
-                        {photo && smallEdge < 800 && (
-                            <p className="border-warning/40 bg-warning-soft text-warning mt-3 rounded-md border px-4 py-2.5 text-sm">
-                                This photo is {photo.width}×{photo.height}. Under 800px it will look soft on the public site.
-                            </p>
-                        )}
-                        {pending.length > 1 && (
-                            <p className="text-body-subtle mt-3 text-xs">
-                                The first photo becomes the main one. Add the rest in the editor.
-                            </p>
-                        )}
-                    </div>
-                </AdminPanel>
-
-                <AdminPanel eyebrow="Details" title="Name it">
-                    <div className="flex flex-col gap-4 p-4">
-                        <label className="flex flex-col gap-1.5">
-                            <span className="text-body-muted text-xs font-bold">Name *</span>
-                            <input
-                                type="text"
-                                value={name}
-                                onChange={(event) => setName(event.target.value)}
-                                placeholder="Grey linen sofa"
-                                className={FIELD}
-                            />
-                        </label>
-
-                        {error && (
-                            <p role="alert" className="border-danger/40 bg-danger-soft text-danger rounded-md border px-4 py-2.5 text-sm">
-                                {error}
-                            </p>
-                        )}
-
-                        <div className="border-line flex flex-wrap items-center gap-2 border-t pt-4">
-                            <button
-                                type="button"
-                                disabled={!canSubmit}
-                                onClick={() => create('edit')}
-                                className="bg-gold-400 text-body-inverse hover:bg-gold-300 inline-flex items-center gap-2 rounded-md px-4 py-2.5 text-sm font-bold transition-colors disabled:cursor-not-allowed disabled:opacity-50"
-                            >
-                                {saving && <Loader2 size={15} aria-hidden="true" className="animate-spin" />}
-                                Create and edit
-                            </button>
-                            <button
-                                type="button"
-                                disabled={!canSubmit}
-                                onClick={() => create('view')}
-                                className="border-line text-body-muted hover:bg-surface-hover hover:text-body rounded-md border px-3.5 py-2.5 text-xs font-bold transition-colors disabled:cursor-not-allowed disabled:opacity-50"
-                            >
-                                Create and view in catalog
-                            </button>
-                        </div>
-
-                        <p className="text-body-subtle text-xs">Price, stock, category and measurements are set in the editor.</p>
-                    </div>
-                </AdminPanel>
-            </div>
+            <AdminPanel eyebrow="Photo and name" title="Add a piece">
+                <div className="p-4">
+                    <CreateInventoryFields
+                        actions={['edit', 'view']}
+                        onCreated={(inventoryId, action) =>
+                            router.push(action === 'edit' ? `/admin/edit?item=${inventoryId}` : `/admin/inventory?item=${inventoryId}`)
+                        }
+                    />
+                </div>
+            </AdminPanel>
         </div>
     );
 }

--- a/src/app/admin/inventory/InventoryConvexClient.tsx
+++ b/src/app/admin/inventory/InventoryConvexClient.tsx
@@ -396,13 +396,7 @@ export default function InventoryConvexClient() {
 
             {lightbox && <PhotoLightbox src={lightbox.src} alt={lightbox.alt} onClose={() => setLightbox(null)} />}
 
-            {showAddOverlay && (
-                <AddInventoryOverlay
-                    onClose={() => setShowAddOverlay(false)}
-                    onSuccess={() => setShowAddOverlay(false)}
-                    defaultAction="stay"
-                />
-            )}
+            {showAddOverlay && <AddInventoryOverlay onClose={() => setShowAddOverlay(false)} />}
         </div>
     );
 }

--- a/src/app/admin/inventory/catalog.types.ts
+++ b/src/app/admin/inventory/catalog.types.ts
@@ -3,6 +3,7 @@ import type { StagingItem } from '@/components/admin/inventory/staging.types';
 /** One catalog row as `inventory.getCatalog` returns it, with availability already derived. */
 export interface CatalogItem extends StagingItem {
     oId: number;
+    createdAt: number;
     location: string;
     active: boolean;
     imagePath: string;

--- a/src/app/admin/projects/[id]/inventory/picker.types.ts
+++ b/src/app/admin/projects/[id]/inventory/picker.types.ts
@@ -3,6 +3,7 @@ import type { StagingItem } from '@/components/admin/inventory/staging.types';
 /** One catalog row as the picker sees it, with availability already derived server-side. */
 export interface PickerItem extends StagingItem {
     oId: number;
+    createdAt: number;
     location: string;
     description: string;
     imagePath: string;

--- a/src/components/AddInventoryOverlay.tsx
+++ b/src/components/AddInventoryOverlay.tsx
@@ -1,491 +1,68 @@
 'use client';
 
-import { useState, useCallback } from 'react';
-import { useDialogFocus } from '@/hooks/useDialogFocus';
-import Image from 'next/image';
 import { useRouter } from 'next/navigation';
-import { useMutation } from 'convex/react';
-import { api } from '@/convex/_generated/api';
-import { X, Package, Edit, Eye, Loader2, Upload, RotateCcw } from 'lucide-react';
-import { Tooltip } from 'react-tooltip';
-import ResizeUploader from '@/app/admin/edit/ResizeUploader';
-import InputTextbox from '@/components/inputs/InputTextbox';
-import InputSelect from '@/components/inputs/InputSelect';
+import { X } from 'lucide-react';
+
+import { useDialogFocus } from '@/hooks/useDialogFocus';
+import CreateInventoryFields from '@/components/admin/inventory/CreateInventoryFields';
+
+/**
+ * Adding to the catalog without leaving the screen you were on.
+ *
+ * This used to be a 491-line second implementation of item creation: its own upload handling, its
+ * own hardcoded category list, raw colours instead of the admin tokens, a `defaultAction` prop
+ * nothing read, and a 1.5 second delay before it would close. It shares one body with
+ * `/admin/edit/new` now, so the two entry points cannot drift again.
+ *
+ * "Create and add another" leaves the dialog open for the next piece. Nothing needs to be told
+ * about it: the catalog behind this is a live Convex subscription and already shows the new row.
+ */
 
 interface AddInventoryOverlayProps {
     onClose: () => void;
-    onSuccess?: (inventoryId: string) => void;
-    defaultAction?: 'edit' | 'view' | 'stay';
 }
 
-const AddInventoryOverlay: React.FC<AddInventoryOverlayProps> = ({ onClose, onSuccess }) => {
-    const [imageUrl, setImageUrl] = useState('Not yet uploaded');
-    const [width, setWidth] = useState(0);
-    const [height, setHeight] = useState(0);
-    const [title, setTitle] = useState('Not yet uploaded');
-    const [smallImageUrl, setSmallImageUrl] = useState('Not yet uploaded');
-    const [smallWidth, setSmallWidth] = useState(0);
-    const [smallHeight, setSmallHeight] = useState(0);
-    const [isSubmitting, setIsSubmitting] = useState(false);
-    const [statusMessage, setStatusMessage] = useState<{ type: 'success' | 'error'; message: string } | null>(null);
-    const [previewUrl, setPreviewUrl] = useState<string | null>(null);
-    const [isUploading, setIsUploading] = useState(false);
-
-    // Additional form fields
-    const [category, setCategory] = useState('');
-    const [vendor, setVendor] = useState('');
-    const [price, setPrice] = useState(0);
-    const [cost, setCost] = useState(0);
-    const [location, setLocation] = useState('');
-    const [count, setCount] = useState(1);
-    const [realWidth, setRealWidth] = useState(0);
-    const [realHeight, setRealHeight] = useState(0);
-    const [realDepth, setRealDepth] = useState(0);
-
+export default function AddInventoryOverlay({ onClose }: AddInventoryOverlayProps) {
     const router = useRouter();
-    const createInventory = useMutation(api.inventory.createInventory);
-
-    const handleUploadComplete = useCallback(
-        (
-            fileName: string,
-            originalImageUrl: string,
-            smallImageUrl: string,
-            originalWidth: number,
-            originalHeight: number,
-            smallWidth: number,
-            smallHeight: number,
-        ) => {
-            setTitle(fileName.split('.')[0] || 'New Item');
-            setImageUrl(originalImageUrl);
-            setSmallImageUrl(smallImageUrl);
-            setWidth(originalWidth);
-            setHeight(originalHeight);
-            setSmallWidth(smallWidth);
-            setSmallHeight(smallHeight);
-            setStatusMessage(null);
-            setIsUploading(false);
-        },
-        [],
-    );
-
-    const handleFileSelect = useCallback((file: File) => {
-        // Create local preview URL
-        const localUrl = URL.createObjectURL(file);
-        setPreviewUrl(localUrl);
-        setTitle(file.name.split('.')[0] || 'New Item');
-        setStatusMessage(null);
-        setIsUploading(true);
-    }, []);
-
-    const handleResetInputs = useCallback(() => {
-        // Clean up preview URL
-        if (previewUrl) {
-            URL.revokeObjectURL(previewUrl);
-        }
-
-        setImageUrl('Not yet uploaded');
-        setWidth(0);
-        setHeight(0);
-        setTitle('Not yet uploaded');
-        setSmallImageUrl('Not yet uploaded');
-        setSmallWidth(0);
-        setSmallHeight(0);
-        setStatusMessage(null);
-        setPreviewUrl(null);
-        setIsUploading(false);
-        setCategory('');
-        setVendor('');
-        setPrice(0);
-        setCost(0);
-        setLocation('');
-        setCount(1);
-        setRealWidth(0);
-        setRealHeight(0);
-        setRealDepth(0);
-    }, [previewUrl]);
-
-    const handleCreateInventory = async (action: 'edit' | 'view' | 'stay') => {
-        setIsSubmitting(true);
-        setStatusMessage(null);
-
-        try {
-            /* The identifier comes back from the server; two of these open at once used to collide. */
-            const { inventoryId } = await createInventory({
-                active: true,
-                name: title,
-                cost: cost,
-                price: price,
-                vendor: vendor,
-                category: category,
-                description: '',
-                count: count,
-                location: location,
-                realWidth: realWidth,
-                realHeight: realHeight,
-                realDepth: realDepth,
-                imagePath: imageUrl,
-                width: width,
-                height: height,
-                smallImagePath: smallImageUrl,
-                smallWidth: smallWidth,
-                smallHeight: smallHeight,
-            });
-
-            setStatusMessage({ type: 'success', message: 'Inventory created successfully!' });
-
-            // Call onSuccess callback if provided
-            onSuccess?.(inventoryId);
-
-            // Close overlay after short delay for success message
-            setTimeout(() => {
-                onClose();
-
-                // Navigate if requested
-                switch (action) {
-                    case 'edit':
-                        router.push(`/admin/edit?item=${inventoryId}`);
-                        break;
-                    case 'view':
-                        router.push(`/admin/inventory?item=${inventoryId}`);
-                        break;
-                    case 'stay':
-                        // Just refresh the current page
-                        router.refresh();
-                        break;
-                }
-            }, 1500);
-        } catch (error) {
-            console.error('Error creating inventory:', error);
-            setStatusMessage({
-                type: 'error',
-                message: error instanceof Error ? error.message : 'Failed to create inventory',
-            });
-        } finally {
-            setIsSubmitting(false);
-        }
-    };
-
     /* Open for as long as it is mounted; the parent unmounts it to close. */
     const dialogRef = useDialogFocus<HTMLDivElement>(true, onClose);
 
-    const isFormValid = imageUrl !== 'Not yet uploaded' && title !== 'Not yet uploaded' && !isSubmitting;
-
     return (
-        <>
-            <div
-                ref={dialogRef}
-                role="dialog"
-                aria-modal="true"
-                aria-labelledby="add-inventory-title"
-                tabIndex={-1}
-                className="fixed inset-0 z-50 flex items-center justify-center bg-black/75"
-            >
-                <div className="bg-surface relative mx-4 max-h-[90vh] w-full max-w-3xl overflow-hidden rounded-lg shadow-2xl">
-                    {/* Header */}
-                    <div className="bg-surface-raised border-line flex items-center justify-between border-b p-6">
-                        <h2 id="add-inventory-title" className="gradient-secondary-main-text text-2xl font-bold">
-                            Create New Inventory
-                        </h2>
-                        <button
-                            onClick={onClose}
-                            disabled={isSubmitting}
-                            aria-label="Close"
-                            className="bg-surface-overlay hover:bg-surface-hover text-body-muted hover:text-body rounded-full p-2 transition-colors disabled:opacity-50"
-                            data-tooltip-id="close-btn"
-                            data-tooltip-content="Close"
-                        >
-                            <X size={24} aria-hidden="true" />
-                        </button>
-                    </div>
+        <div
+            ref={dialogRef}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="add-inventory-title"
+            tabIndex={-1}
+            className="fixed inset-0 z-50 flex items-center justify-center bg-black/75 p-4"
+        >
+            <div className="bg-surface border-line shadow-overlay relative flex max-h-[90vh] w-full max-w-xl flex-col overflow-hidden rounded-xl border">
+                <div className="border-line bg-surface-raised flex items-center justify-between gap-3 border-b px-5 py-4">
+                    <h2 id="add-inventory-title" className="font-display text-gold-300 text-lg font-bold">
+                        Add to the catalog
+                    </h2>
+                    <button
+                        type="button"
+                        onClick={onClose}
+                        aria-label="Close"
+                        className="border-line text-body-muted hover:bg-surface-hover hover:text-body grid h-9 w-9 place-items-center rounded-md border transition-colors"
+                    >
+                        <X size={17} aria-hidden="true" />
+                    </button>
+                </div>
 
-                    {/* Content */}
-                    <div className="flex h-[calc(90vh-200px)]">
-                        <div className="grid w-full grid-cols-1 gap-6 lg:grid-cols-2">
-                            {/* Preview Section - Left Side */}
-                            <div className="space-y-4 p-6">
-                                <div className="bg-surface-raised flex aspect-square items-center justify-center overflow-hidden rounded-lg">
-                                    {previewUrl ? (
-                                        <img src={previewUrl} alt="Preview" className="h-full w-full object-cover" />
-                                    ) : imageUrl && imageUrl !== 'Not yet uploaded' ? (
-                                        <Image
-                                            src={imageUrl}
-                                            alt="Preview"
-                                            width={width}
-                                            height={height}
-                                            className="h-full w-full object-cover"
-                                        />
-                                    ) : (
-                                        <div className="text-body-subtle text-center">
-                                            <Upload size={48} className="mx-auto mb-2 opacity-50" />
-                                            <p>Image preview will appear here</p>
-                                        </div>
-                                    )}
-                                </div>
-
-                                {imageUrl && imageUrl !== 'Not yet uploaded' && (
-                                    <>
-                                        <div className="text-body-subtle bg-surface-raised grid grid-cols-2 gap-4 rounded-lg p-4 text-sm">
-                                            <div>
-                                                <span className="text-body-muted block font-medium">Dimensions:</span>
-                                                <span>
-                                                    {width} × {height}px
-                                                </span>
-                                            </div>
-                                            <div>
-                                                <span className="text-body-muted block font-medium">Small:</span>
-                                                <span>
-                                                    {smallWidth} × {smallHeight}px
-                                                </span>
-                                            </div>
-                                        </div>
-
-                                        {width < 800 ||
-                                            (height < 800 && (
-                                                <div className="rounded bg-red-900/20 p-3 text-sm text-red-400">
-                                                    ⚠️ Warning: Image dimensions are less than 800px. Consider uploading a larger image for
-                                                    better quality.
-                                                </div>
-                                            ))}
-                                    </>
-                                )}
-                            </div>
-
-                            {/* Form Section - Right Side */}
-                            <div className="overflow-y-auto p-6">
-                                <div className="space-y-4 pb-6">
-                                    {!previewUrl && imageUrl === 'Not yet uploaded' ? (
-                                        /* Upload Button State */
-                                        <div>
-                                            <ResizeUploader
-                                                handleUploadComplete={handleUploadComplete}
-                                                handleResetInputs={handleResetInputs}
-                                                onFileSelect={handleFileSelect}
-                                            />
-                                        </div>
-                                    ) : (
-                                        /* Form Fields State */
-                                        <>
-                                            {/* Upload Status */}
-                                            {isUploading && (
-                                                <div className="bg-surface-raised border-line-strong flex items-center space-x-2 rounded-lg border p-3">
-                                                    <Loader2 size={20} className="text-secondary animate-spin" />
-                                                    <span className="text-body-muted">Processing image...</span>
-                                                </div>
-                                            )}
-
-                                            <InputTextbox
-                                                idName="title"
-                                                name="Item Title"
-                                                value={title}
-                                                onChange={(e) => setTitle(e.target.value)}
-                                            />
-
-                                            <InputSelect
-                                                idName="category"
-                                                name="Category"
-                                                value={category}
-                                                onChange={(e) => setCategory(e.target.value)}
-                                                select_options={[
-                                                    ['', 'Select Category...'],
-                                                    ['Couch', 'Couch'],
-                                                    ['Table', 'Table'],
-                                                    ['Chair', 'Chair'],
-                                                    ['Bedroom', 'Bedroom'],
-                                                    ['Bathroom', 'Bathroom'],
-                                                    ['Kitchen', 'Kitchen'],
-                                                    ['Pillow', 'Pillow'],
-                                                    ['Bookcase', 'Bookcase'],
-                                                    ['Book', 'Book'],
-                                                    ['Lamp', 'Lamp'],
-                                                    ['Art', 'Art'],
-                                                    ['Decor', 'Decor'],
-                                                    ['Bench', 'Bench'],
-                                                    ['Barstool', 'Barstool'],
-                                                    ['Rug', 'Rug'],
-                                                    ['Plant', 'Plant'],
-                                                    ['Desk', 'Desk'],
-                                                    ['Other', 'Other'],
-                                                ]}
-                                            />
-
-                                            <InputTextbox
-                                                idName="vendor"
-                                                name="Vendor"
-                                                value={vendor}
-                                                onChange={(e) => setVendor(e.target.value)}
-                                            />
-
-                                            <InputTextbox
-                                                idName="location"
-                                                name="Location"
-                                                value={location}
-                                                onChange={(e) => setLocation(e.target.value)}
-                                            />
-
-                                            <InputTextbox
-                                                idName="price"
-                                                name="Price ($)"
-                                                value={price.toString()}
-                                                onChange={(e) => setPrice(Number(e.target.value) || 0)}
-                                            />
-
-                                            <InputTextbox
-                                                idName="cost"
-                                                name="Cost ($)"
-                                                value={cost.toString()}
-                                                onChange={(e) => setCost(Number(e.target.value) || 0)}
-                                            />
-
-                                            <InputTextbox
-                                                idName="count"
-                                                name="Count"
-                                                value={count.toString()}
-                                                onChange={(e) => setCount(Number(e.target.value) || 1)}
-                                            />
-
-                                            <InputTextbox
-                                                idName="realWidth"
-                                                name="Width (in)"
-                                                value={realWidth.toString()}
-                                                onChange={(e) => setRealWidth(Number(e.target.value) || 0)}
-                                            />
-
-                                            <InputTextbox
-                                                idName="realHeight"
-                                                name="Height (in)"
-                                                value={realHeight.toString()}
-                                                onChange={(e) => setRealHeight(Number(e.target.value) || 0)}
-                                            />
-
-                                            <InputTextbox
-                                                idName="realDepth"
-                                                name="Depth (in)"
-                                                value={realDepth.toString()}
-                                                onChange={(e) => setRealDepth(Number(e.target.value) || 0)}
-                                            />
-                                        </>
-                                    )}
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-
-                    {/* Status Message */}
-                    {statusMessage && (
-                        <div
-                            className={`mx-6 mb-4 rounded-lg p-3 ${
-                                statusMessage.type === 'success' ? 'bg-green-900 text-green-300' : 'bg-red-900 text-red-300'
-                            }`}
-                        >
-                            {statusMessage.message}
-                        </div>
-                    )}
-
-                    {/* Footer */}
-                    <div className="bg-surface-raised border-line flex items-center justify-between border-t p-6">
-                        <div>
-                            {imageUrl !== 'Not yet uploaded' && (
-                                <button
-                                    onClick={handleResetInputs}
-                                    disabled={isSubmitting}
-                                    className="bg-surface-overlay hover:bg-surface-hover text-body-muted hover:text-body flex items-center space-x-2 rounded-lg px-4 py-2 transition-colors disabled:opacity-50"
-                                    data-tooltip-id="change-image-btn"
-                                    data-tooltip-content="Change the selected image"
-                                >
-                                    <RotateCcw size={16} />
-                                    <span>Change Image</span>
-                                </button>
-                            )}
-                        </div>
-
-                        <div className="flex space-x-3">
-                            <button
-                                onClick={onClose}
-                                disabled={isSubmitting}
-                                className="bg-surface-hover text-body-muted hover:text-body rounded-lg px-4 py-2 transition-colors hover:bg-stone-500 disabled:opacity-50"
-                                data-tooltip-id="cancel-btn"
-                                data-tooltip-content="Cancel creation"
-                            >
-                                Cancel
-                            </button>
-
-                            {imageUrl !== 'Not yet uploaded' && (
-                                <>
-                                    <button
-                                        onClick={() => handleCreateInventory('stay')}
-                                        disabled={!isFormValid}
-                                        className="bg-surface-overlay hover:bg-surface-hover text-body-muted hover:text-body flex items-center space-x-2 rounded-lg px-4 py-2 transition-colors disabled:cursor-not-allowed disabled:opacity-50"
-                                        data-tooltip-id="create-stay-btn"
-                                        data-tooltip-content="Create and stay on current page"
-                                    >
-                                        {isSubmitting ? (
-                                            <>
-                                                <Loader2 size={16} className="animate-spin" />
-                                                <span>Creating...</span>
-                                            </>
-                                        ) : (
-                                            <>
-                                                <Package size={16} />
-                                                <span>Create</span>
-                                            </>
-                                        )}
-                                    </button>
-
-                                    <button
-                                        onClick={() => handleCreateInventory('edit')}
-                                        disabled={!isFormValid}
-                                        className="border-line text-body hover:bg-surface-hover flex items-center space-x-2 rounded-lg border px-4 py-2 transition-colors disabled:cursor-not-allowed disabled:opacity-50"
-                                        data-tooltip-id="create-edit-btn"
-                                        data-tooltip-content="Create and go to edit page"
-                                    >
-                                        {isSubmitting ? (
-                                            <>
-                                                <Loader2 size={16} className="animate-spin" />
-                                                <span>Creating...</span>
-                                            </>
-                                        ) : (
-                                            <>
-                                                <Edit size={16} />
-                                                <span>Create & Edit</span>
-                                            </>
-                                        )}
-                                    </button>
-
-                                    <button
-                                        onClick={() => handleCreateInventory('view')}
-                                        disabled={!isFormValid}
-                                        className="bg-gold-400 hover:bg-gold-300 text-body-inverse flex items-center space-x-2 rounded-lg px-4 py-2 transition-colors disabled:cursor-not-allowed disabled:opacity-50"
-                                        data-tooltip-id="create-view-btn"
-                                        data-tooltip-content="Create and view in inventory"
-                                    >
-                                        {isSubmitting ? (
-                                            <>
-                                                <Loader2 size={16} className="animate-spin" />
-                                                <span>Creating...</span>
-                                            </>
-                                        ) : (
-                                            <>
-                                                <Eye size={16} />
-                                                <span>Create & View</span>
-                                            </>
-                                        )}
-                                    </button>
-                                </>
-                            )}
-                        </div>
-                    </div>
+                <div className="min-h-0 overflow-y-auto p-5">
+                    <CreateInventoryFields
+                        stacked
+                        actions={['stay', 'edit']}
+                        onCreated={(inventoryId, action) => {
+                            if (action === 'stay') return;
+                            onClose();
+                            router.push(`/admin/edit?item=${inventoryId}`);
+                        }}
+                    />
                 </div>
             </div>
-
-            {/* Tooltips */}
-            <Tooltip id="close-btn" />
-            <Tooltip id="cancel-btn" />
-            <Tooltip id="change-image-btn" />
-            <Tooltip id="create-stay-btn" />
-            <Tooltip id="create-edit-btn" />
-            <Tooltip id="create-view-btn" />
-        </>
+        </div>
     );
-};
-
-export default AddInventoryOverlay;
+}

--- a/src/components/admin/inventory/CreateInventoryFields.tsx
+++ b/src/components/admin/inventory/CreateInventoryFields.tsx
@@ -1,0 +1,171 @@
+'use client';
+
+import { useState } from 'react';
+import { useMutation } from 'convex/react';
+import { Loader2 } from 'lucide-react';
+
+import { api } from '@/convex/_generated/api';
+import PendingPhotoTray, { pendingSettled, readyPending, revokePreviews } from '@/components/admin/images/PendingPhotoTray';
+import type { PendingImage } from '@/components/admin/images/images.types';
+
+/**
+ * Adding one piece of furniture to the catalog, shared by the `/admin/edit/new` page and the
+ * modal the catalog and the editor open.
+ *
+ * Deliberately short: a photo and a name is enough to have something to find, and everything that
+ * takes judgement — price, stock, measurements, category — belongs on the editor this hands off to.
+ * The identifier is allocated by the server, so two of these open at once cannot collide.
+ *
+ * The two surfaces had drifted into separate implementations of this, with different field sets and
+ * two different upload paths. One of them also warned about small photos with
+ * `width < 800 || (height < 800 && ...)`, which never fires for a narrow tall image.
+ */
+
+export type CreateInventoryAction = 'edit' | 'view' | 'stay';
+
+const ACTION_LABEL: Record<CreateInventoryAction, string> = {
+    edit: 'Create and edit',
+    view: 'Create and view in catalog',
+    stay: 'Create and add another',
+};
+
+const FIELD =
+    'border-line bg-surface text-body placeholder:text-body-subtle focus-visible:border-gold-300 w-full rounded-md border px-3 py-2.5 text-sm outline-none transition-colors';
+
+const PRIMARY =
+    'bg-gold-400 text-body-inverse hover:bg-gold-300 inline-flex items-center gap-2 rounded-md px-4 py-2.5 text-sm font-bold transition-colors disabled:cursor-not-allowed disabled:opacity-50';
+
+const SECONDARY =
+    'border-line text-body-muted hover:bg-surface-hover hover:text-body rounded-md border px-3.5 py-2.5 text-xs font-bold transition-colors disabled:cursor-not-allowed disabled:opacity-50';
+
+interface CreateInventoryFieldsProps {
+    /** In order; the first is the primary button. `stay` clears the form instead of navigating. */
+    actions: CreateInventoryAction[];
+    onCreated: (inventoryId: string, action: CreateInventoryAction) => void;
+    /** Rendered as one column rather than photo-beside-details. */
+    stacked?: boolean;
+}
+
+export default function CreateInventoryFields({ actions, onCreated, stacked = false }: CreateInventoryFieldsProps) {
+    const createInventory = useMutation(api.inventory.createInventory);
+
+    const [pending, setPending] = useState<PendingImage[]>([]);
+    const [name, setName] = useState('');
+    const [saving, setSaving] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const [justAdded, setJustAdded] = useState<string | null>(null);
+
+    const photo = readyPending(pending)[0];
+    const settled = pendingSettled(pending);
+    const canSubmit = Boolean(photo) && name.trim().length > 0 && settled && !saving;
+    const smallEdge = photo ? Math.min(photo.width ?? 0, photo.height ?? 0) : 0;
+
+    const create = async (action: CreateInventoryAction) => {
+        if (!photo || !canSubmit) return;
+
+        setSaving(true);
+        setError(null);
+        setJustAdded(null);
+        try {
+            const { inventoryId } = await createInventory({
+                active: true,
+                name: name.trim(),
+                cost: 0,
+                price: 0,
+                vendor: '',
+                category: '',
+                description: '',
+                /* One unit until she says otherwise; zero would read as out of stock everywhere. */
+                count: 1,
+                location: '',
+                realWidth: 0,
+                realHeight: 0,
+                realDepth: 0,
+                imagePath: photo.imagePath as string,
+                width: photo.width as number,
+                height: photo.height as number,
+                smallImagePath: photo.thumbnailPath ?? (photo.imagePath as string),
+                smallWidth: photo.thumbnailWidth ?? (photo.width as number),
+                smallHeight: photo.thumbnailHeight ?? (photo.height as number),
+            });
+
+            revokePreviews(pending);
+
+            if (action === 'stay') {
+                /* Bulk entry: keep the form open, ready for the next piece. */
+                setPending([]);
+                setName('');
+                setJustAdded(name.trim());
+                setSaving(false);
+            }
+
+            onCreated(inventoryId, action);
+        } catch (caught) {
+            setError(caught instanceof Error ? caught.message : 'Could not create that item.');
+            setSaving(false);
+        }
+    };
+
+    return (
+        <div className={stacked ? 'flex flex-col gap-5' : 'grid grid-cols-1 gap-5 xl:grid-cols-[3fr_2fr]'}>
+            <div>
+                <PendingPhotoTray
+                    pending={pending}
+                    onPendingChange={(update) => setPending(update)}
+                    onFilesChosen={() => setError(null)}
+                    disabled={saving}
+                />
+                {photo && smallEdge < 800 && (
+                    <p className="border-warning/40 bg-warning-soft text-warning mt-3 rounded-md border px-4 py-2.5 text-sm">
+                        This photo is {photo.width}×{photo.height}. Under 800px it will look soft on the public site.
+                    </p>
+                )}
+                {pending.length > 1 && (
+                    <p className="text-body-subtle mt-3 text-xs">The first photo becomes the main one. Add the rest in the editor.</p>
+                )}
+            </div>
+
+            <div className="flex flex-col gap-4">
+                <label className="flex flex-col gap-1.5">
+                    <span className="text-body-muted text-xs font-bold">Name *</span>
+                    <input
+                        type="text"
+                        value={name}
+                        onChange={(event) => setName(event.target.value)}
+                        placeholder="Grey linen sofa"
+                        className={FIELD}
+                    />
+                </label>
+
+                {error && (
+                    <p role="alert" className="border-danger/40 bg-danger-soft text-danger rounded-md border px-4 py-2.5 text-sm">
+                        {error}
+                    </p>
+                )}
+
+                {justAdded && !error && (
+                    <p role="status" className="border-success/40 bg-success-soft text-success rounded-md border px-4 py-2.5 text-sm">
+                        Added {justAdded}. Ready for the next one.
+                    </p>
+                )}
+
+                <div className="border-line flex flex-wrap items-center gap-2 border-t pt-4">
+                    {actions.map((action, index) => (
+                        <button
+                            key={action}
+                            type="button"
+                            disabled={!canSubmit}
+                            onClick={() => void create(action)}
+                            className={index === 0 ? PRIMARY : SECONDARY}
+                        >
+                            {index === 0 && saving && <Loader2 size={15} aria-hidden="true" className="animate-spin" />}
+                            {ACTION_LABEL[action]}
+                        </button>
+                    ))}
+                </div>
+
+                <p className="text-body-subtle text-xs">Price, stock, category and measurements are set in the editor.</p>
+            </div>
+        </div>
+    );
+}

--- a/src/components/admin/inventory/inventory.types.ts
+++ b/src/components/admin/inventory/inventory.types.ts
@@ -32,6 +32,7 @@ export interface FilterableItem {
     location?: string;
     price: number;
     oId: number;
+    createdAt: number;
     free: number;
     out: number;
     awaitingCheckIn: number;

--- a/src/components/admin/inventory/useInventoryFilters.ts
+++ b/src/components/admin/inventory/useInventoryFilters.ts
@@ -34,7 +34,11 @@ function matchesAvailability(item: FilterableItem, filter: InventoryFilterState[
 }
 
 const SORTERS: Record<InventoryFilterState['sort'], (a: FilterableItem, b: FilterableItem) => number> = {
-    recent: (a, b) => b.oId - a.oId,
+    /*
+     * `createdAt`, not `oId`. The catalog number doubles as manual display order and reordering
+     * swaps it between two rows, so "Recently added" used to mean "wherever she dragged it".
+     */
+    recent: (a, b) => b.createdAt - a.createdAt,
     name: (a, b) => a.name.localeCompare(b.name),
     price: (a, b) => b.price - a.price,
     staged: (a, b) => (b.timesStaged ?? 0) - (a.timesStaged ?? 0),


### PR DESCRIPTION
Closes out the two follow-ups from the audit pass. Net **-367 lines**.

## There were two ways to add an item, and the better one was harder to reach

| | `/admin/edit/new` | `AddInventoryOverlay` |
|---|---|---|
| Lines | 145 | 491 |
| Asks for | photo, name | photo, name, category, vendor, price, cost, location, count, W/H/D |
| Upload | shared `PendingPhotoTray` | own bespoke state, 7 `useState`s of image URLs |
| Styling | admin tokens | `bg-red-900/20`, `gradient-secondary-main-text`, raw `<img>`, `⚠️` |
| Categories | set in the editor | hardcoded list inline in JSX |
| Reachable from | nav / direct URL | **the catalog and the editor** |

The newer surface states its intent in a comment: "a photo and a name is enough to have something to find, and everything that takes judgement belongs on the editor this hands off to." That is the flow that got the deliberate thought, and it was the one Mia was least likely to hit.

Both render one `CreateInventoryFields` now, so they cannot drift again. The modal keeps the thing a modal is for — **"Create and add another"** stays open and clears the form for the next piece, which is the whole reason to add from the catalog instead of the page. Price, stock, category and measurements were already the editor's job on the newer surface and are now the editor's job everywhere.

Two defects came out with the old code:

- The small-photo warning read `width < 800 || (height < 800 && ...)`. Operator precedence means it never fires for a narrow tall image, and when the width is small it renders a bare boolean instead of the warning. The shared version checks the smaller edge.
- The modal showed a success message for 1.5 seconds before closing, against a live Convex subscription that had already rendered the new row.

Also drops the `defaultAction` prop, which was declared, passed as `"stay"` by the catalog, and read by nothing — the three buttons hardcoded their own actions.

## "Recently added" was not sorting by when things were added

`SORTERS.recent` ordered by `oId`. That field doubles as manual display order, and `moveInventoryPosition` swaps it between two rows on every reorder. So the sort labelled **"Recently added"** actually meant "wherever she last dragged it", and an old piece moved to the top of the catalog read as the newest acquisition.

It sorts by `createdAt` now — already present and populated on every row, so no migration. `createdAt` is added to the catalog and picker payloads to carry it.

The catalog's own default arrangement still follows `oId`, and so do the editor's prev/next links, because in those places it genuinely is the manual order.

## Not done, deliberately

A separate `displayOrder` column was the audit's suggestion for the reorder problem. It is not needed: nothing addresses an item by `oId` any more, so reordering can no longer corrupt a save. The only thing left is that the catalog number Mia sees changes when she rearranges, and that only matters if the number is used off-screen — on a tag, in a spreadsheet, in a message. Worth asking her before paying for a migration across 425 live rows.
